### PR TITLE
HU 1: AcidKnob (control rotatorio, arrastre vertical 0…1)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Serie lineal: **Oscilador (sierra/cuadrado)** → **Filtro ladder** (cutoff, res
 
 - La definición del target vive en **`project.yml`** ([XcodeGen](https://github.com/yonaskolb/XcodeGen)). Tras cambiar el YAML: `xcodegen generate` en la raíz del repo.
 - Abre **`AcidMe.xcodeproj`** en Xcode, deja que resuelva los paquetes (**File → Packages → Resolve Package Versions**) y compila el esquema **AcidMe** con destino **iPad** (simulador o dispositivo).
-- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features` (vacío; features por HU), `AcidMe/Resources` (Assets).
+- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables; p. ej. **AcidKnob** en HU 1), `AcidMe/Resources` (Assets).
 
 ## Fuentes de verdad
 

--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 63;
+	objectVersion = 77;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -11,8 +11,10 @@
 		6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */; };
 		882409673B5C11AF4F05E788 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1976140D3190C10989DF090E /* ContentView.swift */; };
 		8F90CFBED1385137F71B1CE6 /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */; };
+		94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */; };
 		9B6E7E9AD60C9F99D2E54C58 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = EC0B52AD9704E1B22B0A1397 /* ComposableArchitecture */; };
 		CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973DB5D629F27409804B1093 /* AcidMeApp.swift */; };
+		E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */; };
 		FDFBC7AC139584F4B17B6589 /* AudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = FE0F508000A1F0425A520A5C /* AudioKit */; };
 /* End PBXBuildFile section */
 
@@ -27,14 +29,15 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnobMathTests.swift; sourceTree = "<group>"; };
 		1976140D3190C10989DF090E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnob.swift; sourceTree = "<group>"; };
 		973DB5D629F27409804B1093 /* AcidMeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidMeApp.swift; sourceTree = "<group>"; };
-		9AC895C0B136AE1C6B69968F /* .gitkeep */ = {isa = PBXFileReference; lastKnownFileType = text; path = .gitkeep; sourceTree = "<group>"; };
 		A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureTests.swift; sourceTree = "<group>"; };
 		C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioKitBootstrap.swift; sourceTree = "<group>"; };
 		CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
 		D12FA876D6E8CEE040984562 /* AcidMeTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AcidMeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		D3B5A66BD50A60974610B2A2 /* AcidMe.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = AcidMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		D3B5A66BD50A60974610B2A2 /* AcidMe.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AcidMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -53,7 +56,7 @@
 		383FE36F63A2407A11565D94 /* Features */ = {
 			isa = PBXGroup;
 			children = (
-				9AC895C0B136AE1C6B69968F /* .gitkeep */,
+				FD110CAF6CFEEA729D033E88 /* Components */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -61,6 +64,7 @@
 		43F95B9EF515F4D1E5404ECF /* AcidMeTests */ = {
 			isa = PBXGroup;
 			children = (
+				1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */,
 				A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */,
 			);
 			path = AcidMeTests;
@@ -110,6 +114,14 @@
 				1976140D3190C10989DF090E /* ContentView.swift */,
 			);
 			path = App;
+			sourceTree = "<group>";
+		};
+		FD110CAF6CFEEA729D033E88 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */,
+			);
+			path = Components;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -176,6 +188,7 @@
 				3144243B1D33DA70B11924BD /* XCRemoteSwiftPackageReference "AudioKit" */,
 				91DB6E2117440E6F950E4F5C /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
 			);
+			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
@@ -190,6 +203,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */,
 				6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -198,6 +212,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */,
 				CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */,
 				8F90CFBED1385137F71B1CE6 /* AppFeature.swift in Sources */,
 				04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */,
@@ -244,10 +259,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = dev.acidme.AcidMe;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Release;
@@ -263,10 +274,6 @@
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = dev.acidme.AcidMe;
 				SDKROOT = iphoneos;
-				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
-				SUPPORTS_MACCATALYST = NO;
-				SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = NO;
-				SUPPORTS_XR_DESIGNED_FOR_IPHONE_IPAD = NO;
 				TARGETED_DEVICE_FAMILY = 2;
 			};
 			name = Debug;

--- a/AcidMe.xcodeproj/xcshareddata/xcschemes/AcidMe.xcscheme
+++ b/AcidMe.xcodeproj/xcshareddata/xcschemes/AcidMe.xcscheme
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "1430"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
-      buildImplicitDependencies = "YES">
+      buildImplicitDependencies = "YES"
+      runPostActionsOnFailure = "NO">
       <BuildActionEntries>
          <BuildActionEntry
             buildForTesting = "YES"
@@ -40,7 +41,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "NO">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -63,6 +65,8 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
+      <CommandLineArguments>
+      </CommandLineArguments>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -6,13 +6,26 @@ struct AppView: View {
     
     var body: some View {
         WithPerceptionTracking {
-            VStack(spacing: 16) {
+            VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 0 · iPad · Landscape · TCA + AudioKit")
+                Text("HU 1 · AcidKnob (arrastre vertical → 0…1)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
+
+                AcidKnob(
+                    value: Binding(
+                        get: { store.demoKnobValue },
+                        set: { store.send(.demoKnobValueChanged($0)) }
+                    ),
+                    label: "DEMO"
+                )
+
+                Text(String(format: "valor: %.3f", store.demoKnobValue))
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.tertiary)
+
                 if AudioKitBootstrap.isModuleLinked {
                     Text("AudioKit enlazado")
                         .font(.caption2)

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -5,13 +5,22 @@ import Foundation
 @Reducer
 struct AppFeature {
     @ObservableState
-    struct State: Equatable {}
+    struct State: Equatable {
+        /// Valor de demostración del AcidKnob (HU 1); más adelante se sustituirá por parámetros reales de síntesis.
+        var demoKnobValue: Double = 0.35
+    }
 
-    enum Action: Equatable {}
+    enum Action: Equatable {
+        case demoKnobValueChanged(Double)
+    }
 
     var body: some ReducerOf<Self> {
-        Reduce { _, _ in
-            .none
+        Reduce { state, action in
+            switch action {
+            case let .demoKnobValueChanged(v):
+                state.demoKnobValue = min(1, max(0, v))
+                return .none
+            }
         }
     }
 }

--- a/AcidMe/Features/Components/AcidKnob.swift
+++ b/AcidMe/Features/Components/AcidKnob.swift
@@ -1,0 +1,160 @@
+import SwiftUI
+
+// MARK: - Lógica pura (testeable)
+
+enum AcidKnobMath {
+    /// Recorre vertical completo en `pixelsForFullRange` puntos ⇒ delta 1.0 (hacia arriba aumenta).
+    static func valueAfterVerticalDrag(
+        origin: Double,
+        translationHeight: CGFloat,
+        pixelsForFullRange: CGFloat
+    ) -> Double {
+        guard pixelsForFullRange > 0 else { return clamp(origin) }
+        let delta = -Double(translationHeight) / Double(pixelsForFullRange)
+        return clamp(origin + delta)
+    }
+
+    static func clamp(_ value: Double) -> Double {
+        min(1, max(0, value))
+    }
+
+    /// Ángulo del indicador: 0 → mínimo, 1 → máximo (arco ~270°).
+    static func indicatorDegrees(value: Double) -> Double {
+        let v = clamp(value)
+        return -135 + v * 270
+    }
+}
+
+// MARK: - Vista
+
+/// Control rotatorio estilo hardware: arrastre **vertical** mapea a `0...1` y el dial gira.
+struct AcidKnob: View {
+    @Binding var value: Double
+    var label: String?
+    /// Diámetro del knob.
+    var size: CGFloat = 88
+    /// Píxeles de arrastre vertical para recorrer todo el rango 0→1.
+    var pixelsForFullRange: CGFloat = 200
+
+    @State private var isDragging = false
+    @State private var valueAtDragStart: Double = 0
+
+    private var clampedBinding: Binding<Double> {
+        Binding(
+            get: { AcidKnobMath.clamp(value) },
+            set: { value = AcidKnobMath.clamp($0) }
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 6) {
+            knobBody
+            if let label {
+                Text(label)
+                    .font(.caption2.weight(.semibold))
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label ?? "Parámetro")
+        .accessibilityValue("\(Int(AcidKnobMath.clamp(value) * 100)) por ciento")
+        .accessibilityAdjustableAction { direction in
+            let step = 0.02
+            switch direction {
+            case .increment:
+                clampedBinding.wrappedValue = AcidKnobMath.clamp(clampedBinding.wrappedValue + step)
+            case .decrement:
+                clampedBinding.wrappedValue = AcidKnobMath.clamp(clampedBinding.wrappedValue - step)
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    private var knobBody: some View {
+        ZStack {
+            Circle()
+                .fill(metalKnobFill)
+            Circle()
+                .strokeBorder(
+                    LinearGradient(
+                        colors: [
+                            Color(white: 0.55),
+                            Color(white: 0.22),
+                            Color(white: 0.4),
+                        ],
+                        startPoint: .topLeading,
+                        endPoint: .bottomTrailing
+                    ),
+                    lineWidth: max(2, size * 0.04)
+                )
+            Circle()
+                .fill(
+                    RadialGradient(
+                        colors: [Color.white.opacity(0.35), Color.clear],
+                        center: .topLeading,
+                        startRadius: 0,
+                        endRadius: size * 0.9
+                    )
+                )
+                .padding(size * 0.08)
+
+            indicator
+        }
+        .frame(width: size, height: size)
+        .contentShape(Circle())
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { gesture in
+                    if !isDragging {
+                        isDragging = true
+                        valueAtDragStart = AcidKnobMath.clamp(value)
+                    }
+                    let next = AcidKnobMath.valueAfterVerticalDrag(
+                        origin: valueAtDragStart,
+                        translationHeight: gesture.translation.height,
+                        pixelsForFullRange: pixelsForFullRange
+                    )
+                    value = next
+                }
+                .onEnded { _ in
+                    isDragging = false
+                }
+        )
+    }
+
+    private var indicator: some View {
+        RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+            .fill(Color(white: 0.12))
+            .frame(width: max(3, size * 0.045), height: size * 0.22)
+            .offset(y: -size * 0.31)
+            .rotationEffect(.degrees(AcidKnobMath.indicatorDegrees(value: value)))
+    }
+
+    private var metalKnobFill: some ShapeStyle {
+        RadialGradient(
+            colors: [
+                Color(white: 0.52),
+                Color(white: 0.38),
+                Color(white: 0.28),
+                Color(white: 0.42),
+            ],
+            center: .init(x: 0.35, y: 0.3),
+            startRadius: 0,
+            endRadius: size
+        )
+    }
+}
+
+#Preview("AcidKnob") {
+    struct PreviewHost: View {
+        @State private var v = 0.35
+        var body: some View {
+            ZStack {
+                Color.black.opacity(0.2)
+                AcidKnob(value: $v, label: "DEMO")
+            }
+        }
+    }
+    return PreviewHost()
+}

--- a/AcidMeTests/AcidKnobMathTests.swift
+++ b/AcidMeTests/AcidKnobMathTests.swift
@@ -1,0 +1,37 @@
+import Testing
+
+@testable import AcidMe
+
+@Suite("AcidKnobMath")
+struct AcidKnobMathTests {
+    @Test func clampMantieneRango() {
+        #expect(AcidKnobMath.clamp(-0.5) == 0)
+        #expect(AcidKnobMath.clamp(0) == 0)
+        #expect(AcidKnobMath.clamp(0.5) == 0.5)
+        #expect(AcidKnobMath.clamp(1) == 1)
+        #expect(AcidKnobMath.clamp(1.25) == 1)
+    }
+
+    @Test func dragHaciaArribaAumentaValor() {
+        let next = AcidKnobMath.valueAfterVerticalDrag(
+            origin: 0.5,
+            translationHeight: -100,
+            pixelsForFullRange: 200
+        )
+        #expect(next == 1.0)
+    }
+
+    @Test func dragHaciaAbajoDisminuyeValor() {
+        let next = AcidKnobMath.valueAfterVerticalDrag(
+            origin: 0.5,
+            translationHeight: 100,
+            pixelsForFullRange: 200
+        )
+        #expect(next == 0)
+    }
+
+    @Test func indicadorExtremos() {
+        #expect(AcidKnobMath.indicatorDegrees(value: 0) == -135)
+        #expect(AcidKnobMath.indicatorDegrees(value: 1) == 135)
+    }
+}

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -13,4 +13,17 @@ struct AppFeatureTests {
         }
         #expect(store.state == AppFeature.State())
     }
+
+    @Test
+    func demoKnobValueChanged_acotaEntreCeroYUno() async {
+        let store = TestStore(initialState: AppFeature.State(demoKnobValue: 0.5)) {
+            AppFeature()
+        }
+        await store.send(.demoKnobValueChanged(2)) {
+            $0.demoKnobValue = 1
+        }
+        await store.send(.demoKnobValueChanged(-1)) {
+            $0.demoKnobValue = 0
+        }
+    }
 }


### PR DESCRIPTION
## HU 1 — HUN-1 AcidKnob
- Control rotatorio con **arrastre vertical** que mapea a **0.0…1.0** (hacia arriba sube).
- **Indicador** en arco ~270°; relleno y bordes tipo **metal**.
- `AcidKnobMath`: funciones puras (**clamp**, valor tras drag, ángulo) con **Swift Testing**.
- **AppFeature**: `demoKnobValue` + `.demoKnobValueChanged` con clamp; demo en `AppView`.
- Accesibilidad: etiqueta, valor en %, acciones incremento/decremento.

Cierra la issue **HU 1** del proyecto al mergear si procede.

### Cómo probar
Abrir en iPad simulador, arrastrar verticalmente sobre el knob; el texto `valor:` debe actualizarse.

Made with [Cursor](https://cursor.com)