### PR TITLE
HU 2: AcidToggle (interruptor vertical A/B)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Serie lineal: **Oscilador (sierra/cuadrado)** → **Filtro ladder** (cutoff, res
 
 - La definición del target vive en **`project.yml`** ([XcodeGen](https://github.com/yonaskolb/XcodeGen)). Tras cambiar el YAML: `xcodegen generate` en la raíz del repo.
 - Abre **`AcidMe.xcodeproj`** en Xcode, deja que resuelva los paquetes (**File → Packages → Resolve Package Versions**) y compila el esquema **AcidMe** con destino **iPad** (simulador o dispositivo).
-- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables; p. ej. **AcidKnob** en HU 1), `AcidMe/Resources` (Assets).
+- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables: **AcidKnob**, **AcidToggle**), `AcidMe/Resources` (Assets).
 
 ## Fuentes de verdad
 

--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */; };
 		05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72527E242323BE0F165CB92F /* AcidToggle.swift */; };
 		6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */; };
+		86E3B0D5A89CC26FCF922CCB /* AudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = FE0F508000A1F0425A520A5C /* AudioKit */; };
 		882409673B5C11AF4F05E788 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1976140D3190C10989DF090E /* ContentView.swift */; };
 		8F90CFBED1385137F71B1CE6 /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */; };
 		94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */; };
@@ -17,7 +18,7 @@
 		9B6E7E9AD60C9F99D2E54C58 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = EC0B52AD9704E1B22B0A1397 /* ComposableArchitecture */; };
 		CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973DB5D629F27409804B1093 /* AcidMeApp.swift */; };
 		E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */; };
-		FDFBC7AC139584F4B17B6589 /* AudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = FE0F508000A1F0425A520A5C /* AudioKit */; };
+		FDFBC7AC139584F4B17B6589 /* Perception in Frameworks */ = {isa = PBXBuildFile; productRef = 2D0348C6BA11532A7A728F65 /* Perception */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -50,7 +51,8 @@
 			buildActionMask = 2147483647;
 			files = (
 				9B6E7E9AD60C9F99D2E54C58 /* ComposableArchitecture in Frameworks */,
-				FDFBC7AC139584F4B17B6589 /* AudioKit in Frameworks */,
+				FDFBC7AC139584F4B17B6589 /* Perception in Frameworks */,
+				86E3B0D5A89CC26FCF922CCB /* AudioKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -165,6 +167,7 @@
 			name = AcidMe;
 			packageProductDependencies = (
 				EC0B52AD9704E1B22B0A1397 /* ComposableArchitecture */,
+				2D0348C6BA11532A7A728F65 /* Perception */,
 				FE0F508000A1F0425A520A5C /* AudioKit */,
 			);
 			productName = AcidMe;
@@ -193,6 +196,7 @@
 			packageReferences = (
 				3144243B1D33DA70B11924BD /* XCRemoteSwiftPackageReference "AudioKit" */,
 				91DB6E2117440E6F950E4F5C /* XCRemoteSwiftPackageReference "swift-composable-architecture" */,
+				CBE0DC747D6DE90C23370B8C /* XCRemoteSwiftPackageReference "swift-perception" */,
 			);
 			preferredProjectObjectVersion = 77;
 			projectDirPath = "";
@@ -481,9 +485,22 @@
 				minimumVersion = 1.16.0;
 			};
 		};
+		CBE0DC747D6DE90C23370B8C /* XCRemoteSwiftPackageReference "swift-perception" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-perception";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		2D0348C6BA11532A7A728F65 /* Perception */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = CBE0DC747D6DE90C23370B8C /* XCRemoteSwiftPackageReference "swift-perception" */;
+			productName = Perception;
+		};
 		EC0B52AD9704E1B22B0A1397 /* ComposableArchitecture */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 91DB6E2117440E6F950E4F5C /* XCRemoteSwiftPackageReference "swift-composable-architecture" */;

--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -8,10 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */; };
+		05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72527E242323BE0F165CB92F /* AcidToggle.swift */; };
 		6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */; };
 		882409673B5C11AF4F05E788 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1976140D3190C10989DF090E /* ContentView.swift */; };
 		8F90CFBED1385137F71B1CE6 /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */; };
 		94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */; };
+		97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */; };
 		9B6E7E9AD60C9F99D2E54C58 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = EC0B52AD9704E1B22B0A1397 /* ComposableArchitecture */; };
 		CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973DB5D629F27409804B1093 /* AcidMeApp.swift */; };
 		E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */; };
@@ -29,8 +31,10 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggleSelectionTests.swift; sourceTree = "<group>"; };
 		1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnobMathTests.swift; sourceTree = "<group>"; };
 		1976140D3190C10989DF090E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		72527E242323BE0F165CB92F /* AcidToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggle.swift; sourceTree = "<group>"; };
 		85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnob.swift; sourceTree = "<group>"; };
 		973DB5D629F27409804B1093 /* AcidMeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidMeApp.swift; sourceTree = "<group>"; };
 		A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureTests.swift; sourceTree = "<group>"; };
@@ -65,6 +69,7 @@
 			isa = PBXGroup;
 			children = (
 				1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */,
+				0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */,
 				A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */,
 			);
 			path = AcidMeTests;
@@ -120,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */,
+				72527E242323BE0F165CB92F /* AcidToggle.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -204,6 +210,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */,
+				97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */,
 				6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -214,6 +221,7 @@
 			files = (
 				E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */,
 				CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */,
+				05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */,
 				8F90CFBED1385137F71B1CE6 /* AppFeature.swift in Sources */,
 				04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */,
 				882409673B5C11AF4F05E788 /* ContentView.swift in Sources */,

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -2,8 +2,9 @@ import ComposableArchitecture
 import SwiftUI
 
 struct AppView: View {
-    let store: StoreOf<AppFeature>
-    
+    /// `@Bindable` evita avisos de Perception al crear `Binding` que leen `store.*` (p. ej. `demoKnobValue`).
+    @Bindable var store: StoreOf<AppFeature>
+
     var body: some View {
         WithPerceptionTracking {
             VStack(spacing: 24) {

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -9,7 +9,7 @@ struct AppView: View {
             VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 2 · AcidKnob + AcidToggle (toque → A/B)")
+                Text("HU 2 · AcidKnob + AcidToggle horizontal (toque → A/B)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -33,8 +33,8 @@ struct AppView: View {
                             get: { store.demoToggleSelection },
                             set: { store.send(.demoToggleSelectionChanged($0)) }
                         ),
-                        upperLabel: "SAW",
-                        lowerLabel: "SQR"
+                        leadingLabel: "SAW",
+                        trailingLabel: "SQR"
                     )
 
                     Text(store.demoToggleSelection == .upper ? "Onda: sierra" : "Onda: cuadrada")

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -2,7 +2,7 @@ import ComposableArchitecture
 import SwiftUI
 
 struct AppView: View {
-    /// `@Bindable` evita avisos de Perception al crear `Binding` que leen `store.*` (p. ej. `demoKnobValue`).
+    /// Con `BindingReducer`, las proyecciones `$store.*` están enlazadas a Perception (sin `Binding { get set }` manual).
     @Bindable var store: StoreOf<AppFeature>
 
     var body: some View {
@@ -18,10 +18,7 @@ struct AppView: View {
                 HStack(alignment: .center, spacing: 48) {
                     VStack(spacing: 8) {
                         AcidKnob(
-                            value: Binding(
-                                get: { store.demoKnobValue },
-                                set: { store.send(.demoKnobValueChanged($0)) }
-                            ),
+                            value: $store.demoKnobValue,
                             label: "DEMO"
                         )
                         Text(String(format: "valor: %.3f", store.demoKnobValue))
@@ -30,10 +27,7 @@ struct AppView: View {
                     }
 
                     AcidToggle(
-                        selection: Binding(
-                            get: { store.demoToggleSelection },
-                            set: { store.send(.demoToggleSelectionChanged($0)) }
-                        ),
+                        selection: $store.demoToggleSelection,
                         leadingLabel: "SAW",
                         trailingLabel: "SQR"
                     )

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -1,9 +1,10 @@
 import ComposableArchitecture
+import Perception
 import SwiftUI
 
 struct AppView: View {
-    /// Con `BindingReducer`, las proyecciones `$store.*` están enlazadas a Perception (sin `Binding { get set }` manual).
-    @Bindable var store: StoreOf<AppFeature>
+    /// `Perception.Bindable` evita la ambigüedad con `SwiftUI.Bindable` y enlaza el `Store` a Perception.
+    @Perception.Bindable var store: StoreOf<AppFeature>
 
     var body: some View {
         WithPerceptionTracking {

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -9,22 +9,39 @@ struct AppView: View {
             VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 1 · AcidKnob (arrastre vertical → 0…1)")
+                Text("HU 2 · AcidKnob + AcidToggle (toque → A/B)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
 
-                AcidKnob(
-                    value: Binding(
-                        get: { store.demoKnobValue },
-                        set: { store.send(.demoKnobValueChanged($0)) }
-                    ),
-                    label: "DEMO"
-                )
+                HStack(alignment: .center, spacing: 48) {
+                    VStack(spacing: 8) {
+                        AcidKnob(
+                            value: Binding(
+                                get: { store.demoKnobValue },
+                                set: { store.send(.demoKnobValueChanged($0)) }
+                            ),
+                            label: "DEMO"
+                        )
+                        Text(String(format: "valor: %.3f", store.demoKnobValue))
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.tertiary)
+                    }
 
-                Text(String(format: "valor: %.3f", store.demoKnobValue))
-                    .font(.caption.monospacedDigit())
-                    .foregroundStyle(.tertiary)
+                    AcidToggle(
+                        selection: Binding(
+                            get: { store.demoToggleSelection },
+                            set: { store.send(.demoToggleSelectionChanged($0)) }
+                        ),
+                        upperLabel: "SAW",
+                        lowerLabel: "SQR"
+                    )
+
+                    Text(store.demoToggleSelection == .upper ? "Onda: sierra" : "Onda: cuadrada")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .frame(minWidth: 120, alignment: .leading)
+                }
 
                 if AudioKitBootstrap.isModuleLinked {
                     Text("AudioKit enlazado")

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -12,19 +12,17 @@ struct AppFeature {
         var demoToggleSelection: AcidToggleSelection = .upper
     }
 
-    enum Action: Equatable {
-        case demoKnobValueChanged(Double)
-        case demoToggleSelectionChanged(AcidToggleSelection)
+    enum Action: BindableAction, Equatable {
+        case binding(BindingAction<State>)
     }
 
     var body: some ReducerOf<Self> {
+        BindingReducer()
         Reduce { state, action in
             switch action {
-            case let .demoKnobValueChanged(v):
-                state.demoKnobValue = min(1, max(0, v))
-                return .none
-            case let .demoToggleSelectionChanged(sel):
-                state.demoToggleSelection = sel
+            case .binding:
+                // Tras cualquier binding, mantiene el knob en 0…1 (p. ej. arrastre del AcidKnob).
+                state.demoKnobValue = min(1, max(0, state.demoKnobValue))
                 return .none
             }
         }

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -8,10 +8,13 @@ struct AppFeature {
     struct State: Equatable {
         /// Valor de demostración del AcidKnob (HU 1); más adelante se sustituirá por parámetros reales de síntesis.
         var demoKnobValue: Double = 0.35
+        /// Selección del AcidToggle (HU 2); p. ej. onda superior/inferior o FX.
+        var demoToggleSelection: AcidToggleSelection = .upper
     }
 
     enum Action: Equatable {
         case demoKnobValueChanged(Double)
+        case demoToggleSelectionChanged(AcidToggleSelection)
     }
 
     var body: some ReducerOf<Self> {
@@ -19,6 +22,9 @@ struct AppFeature {
             switch action {
             case let .demoKnobValueChanged(v):
                 state.demoKnobValue = min(1, max(0, v))
+                return .none
+            case let .demoToggleSelectionChanged(sel):
+                state.demoToggleSelection = sel
                 return .none
             }
         }

--- a/AcidMe/Features/Components/AcidToggle.swift
+++ b/AcidMe/Features/Components/AcidToggle.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Modelo (testeable)
+
+/// Posición del interruptor vertical (p. ej. forma de onda A/B o FX off/on).
+enum AcidToggleSelection: Equatable, CaseIterable {
+    case upper
+    case lower
+
+    mutating func toggle() {
+        self = Self.toggled(self)
+    }
+
+    static func toggled(_ current: Self) -> Self {
+        current == .upper ? .lower : .upper
+    }
+}
+
+// MARK: - Vista
+
+/// Interruptor **vertical** estilo hardware: dos posiciones; un **toque** alterna y actualiza el binding.
+struct AcidToggle: View {
+    @Binding var selection: AcidToggleSelection
+    var upperLabel: String
+    var lowerLabel: String
+    var trackWidth: CGFloat = 40
+    var trackHeight: CGFloat = 104
+    var usesHaptics: Bool = true
+
+    private let thumbSize: CGFloat = 28
+
+    private var thumbCenterY: CGFloat {
+        switch selection {
+        case .upper:
+            return trackHeight * 0.28
+        case .lower:
+            return trackHeight * 0.72
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Text(upperLabel)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(minWidth: trackWidth + 24)
+
+            ZStack {
+                trackChrome
+                thumb
+            }
+            .frame(width: trackWidth, height: trackHeight)
+            .contentShape(Rectangle())
+            .onTapGesture {
+                toggleSelection()
+            }
+
+            Text(lowerLabel)
+                .font(.caption2.weight(.semibold))
+                .foregroundStyle(.secondary)
+                .frame(minWidth: trackWidth + 24)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(upperLabel) o \(lowerLabel)")
+        .accessibilityValue(selection == .upper ? upperLabel : lowerLabel)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction(named: "Alternar") {
+            toggleSelection()
+        }
+    }
+
+    private var trackChrome: some View {
+        RoundedRectangle(cornerRadius: trackWidth / 2, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: [
+                        Color(white: 0.48),
+                        Color(white: 0.32),
+                        Color(white: 0.4),
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: trackWidth / 2, style: .continuous)
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [
+                                Color(white: 0.6),
+                                Color(white: 0.22),
+                                Color(white: 0.45),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: 2
+                    )
+            )
+            .shadow(color: .black.opacity(0.25), radius: 2, y: 1)
+    }
+
+    private var thumb: some View {
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [
+                        Color(white: 0.75),
+                        Color(white: 0.42),
+                        Color(white: 0.34),
+                    ],
+                    center: .init(x: 0.35, y: 0.3),
+                    startRadius: 0,
+                    endRadius: thumbSize
+                )
+            )
+            .overlay(
+                Circle()
+                    .strokeBorder(Color(white: 0.2), lineWidth: 1)
+            )
+            .frame(width: thumbSize, height: thumbSize)
+            .position(x: trackWidth / 2, y: thumbCenterY)
+    }
+
+    private func toggleSelection() {
+        if usesHaptics {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        }
+        withAnimation(.spring(response: 0.34, dampingFraction: 0.78)) {
+            selection = AcidToggleSelection.toggled(selection)
+        }
+    }
+}
+
+#Preview("AcidToggle onda") {
+    struct Host: View {
+        @State private var sel = AcidToggleSelection.upper
+        var body: some View {
+            ZStack {
+                Color.black.opacity(0.15)
+                AcidToggle(
+                    selection: $sel,
+                    upperLabel: "SAW",
+                    lowerLabel: "SQR"
+                )
+            }
+        }
+    }
+    return Host()
+}

--- a/AcidMe/Features/Components/AcidToggle.swift
+++ b/AcidMe/Features/Components/AcidToggle.swift
@@ -3,7 +3,7 @@ import UIKit
 
 // MARK: - Modelo (testeable)
 
-/// Posición del interruptor vertical (p. ej. forma de onda A/B o FX off/on).
+/// Dos posiciones del interruptor: **`.upper`** = extremo **leading** (izquierda en LTR), **`.lower`** = **trailing** (derecha).
 enum AcidToggleSelection: Equatable, CaseIterable {
     case upper
     case lower
@@ -19,32 +19,40 @@ enum AcidToggleSelection: Equatable, CaseIterable {
 
 // MARK: - Vista
 
-/// Interruptor **vertical** estilo hardware: dos posiciones; un **toque** alterna y actualiza el binding.
+/// Interruptor **horizontal** estilo hardware: carril ancho, thumb izquierda/derecha; un **toque** alterna el binding.
 struct AcidToggle: View {
     @Binding var selection: AcidToggleSelection
-    var upperLabel: String
-    var lowerLabel: String
-    var trackWidth: CGFloat = 40
-    var trackHeight: CGFloat = 104
+    /// Etiqueta del lado **leading** (opción `.upper`).
+    var leadingLabel: String
+    /// Etiqueta del lado **trailing** (opción `.lower`).
+    var trailingLabel: String
+    /// Longitud horizontal del carril.
+    var trackWidth: CGFloat = 104
+    /// Grosor vertical del carril.
+    var trackHeight: CGFloat = 40
     var usesHaptics: Bool = true
 
     private let thumbSize: CGFloat = 28
 
-    private var thumbCenterY: CGFloat {
+    private var thumbCenterX: CGFloat {
         switch selection {
         case .upper:
-            return trackHeight * 0.28
+            return trackWidth * 0.28
         case .lower:
-            return trackHeight * 0.72
+            return trackWidth * 0.72
         }
     }
 
+    private var trackCornerRadius: CGFloat {
+        trackHeight / 2
+    }
+
     var body: some View {
-        VStack(spacing: 8) {
-            Text(upperLabel)
+        HStack(alignment: .center, spacing: 10) {
+            Text(leadingLabel)
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(.secondary)
-                .frame(minWidth: trackWidth + 24)
+                .frame(minWidth: 36, alignment: .trailing)
 
             ZStack {
                 trackChrome
@@ -56,14 +64,14 @@ struct AcidToggle: View {
                 toggleSelection()
             }
 
-            Text(lowerLabel)
+            Text(trailingLabel)
                 .font(.caption2.weight(.semibold))
                 .foregroundStyle(.secondary)
-                .frame(minWidth: trackWidth + 24)
+                .frame(minWidth: 36, alignment: .leading)
         }
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(upperLabel) o \(lowerLabel)")
-        .accessibilityValue(selection == .upper ? upperLabel : lowerLabel)
+        .accessibilityLabel("\(leadingLabel) o \(trailingLabel)")
+        .accessibilityValue(selection == .upper ? leadingLabel : trailingLabel)
         .accessibilityAddTraits(.isButton)
         .accessibilityAction(named: "Alternar") {
             toggleSelection()
@@ -71,7 +79,7 @@ struct AcidToggle: View {
     }
 
     private var trackChrome: some View {
-        RoundedRectangle(cornerRadius: trackWidth / 2, style: .continuous)
+        RoundedRectangle(cornerRadius: trackCornerRadius, style: .continuous)
             .fill(
                 LinearGradient(
                     colors: [
@@ -79,12 +87,12 @@ struct AcidToggle: View {
                         Color(white: 0.32),
                         Color(white: 0.4),
                     ],
-                    startPoint: .leading,
-                    endPoint: .trailing
+                    startPoint: .top,
+                    endPoint: .bottom
                 )
             )
             .overlay(
-                RoundedRectangle(cornerRadius: trackWidth / 2, style: .continuous)
+                RoundedRectangle(cornerRadius: trackCornerRadius, style: .continuous)
                     .strokeBorder(
                         LinearGradient(
                             colors: [
@@ -120,7 +128,7 @@ struct AcidToggle: View {
                     .strokeBorder(Color(white: 0.2), lineWidth: 1)
             )
             .frame(width: thumbSize, height: thumbSize)
-            .position(x: trackWidth / 2, y: thumbCenterY)
+            .position(x: thumbCenterX, y: trackHeight / 2)
     }
 
     private func toggleSelection() {
@@ -141,8 +149,8 @@ struct AcidToggle: View {
                 Color.black.opacity(0.15)
                 AcidToggle(
                     selection: $sel,
-                    upperLabel: "SAW",
-                    lowerLabel: "SQR"
+                    leadingLabel: "SAW",
+                    trailingLabel: "SQR"
                 )
             }
         }

--- a/AcidMeTests/AcidToggleSelectionTests.swift
+++ b/AcidMeTests/AcidToggleSelectionTests.swift
@@ -1,0 +1,19 @@
+import Testing
+
+@testable import AcidMe
+
+@Suite("AcidToggleSelection")
+struct AcidToggleSelectionTests {
+    @Test func toggledAlterna() {
+        #expect(AcidToggleSelection.toggled(.upper) == .lower)
+        #expect(AcidToggleSelection.toggled(.lower) == .upper)
+    }
+
+    @Test func toggleMutating() {
+        var s = AcidToggleSelection.upper
+        s.toggle()
+        #expect(s == .lower)
+        s.toggle()
+        #expect(s == .upper)
+    }
+}

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -26,4 +26,17 @@ struct AppFeatureTests {
             $0.demoKnobValue = 0
         }
     }
+
+    @Test
+    func demoToggleSelectionChanged_actualizaEstado() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+        await store.send(.demoToggleSelectionChanged(.lower)) {
+            $0.demoToggleSelection = .lower
+        }
+        await store.send(.demoToggleSelectionChanged(.upper)) {
+            $0.demoToggleSelection = .upper
+        }
+    }
 }

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -15,27 +15,27 @@ struct AppFeatureTests {
     }
 
     @Test
-    func demoKnobValueChanged_acotaEntreCeroYUno() async {
+    func binding_demoKnobValue_acotaEntreCeroYUno() async {
         let store = TestStore(initialState: AppFeature.State(demoKnobValue: 0.5)) {
             AppFeature()
         }
-        await store.send(.demoKnobValueChanged(2)) {
+        await store.send(.binding(.set(\.demoKnobValue, 2))) {
             $0.demoKnobValue = 1
         }
-        await store.send(.demoKnobValueChanged(-1)) {
+        await store.send(.binding(.set(\.demoKnobValue, -1))) {
             $0.demoKnobValue = 0
         }
     }
 
     @Test
-    func demoToggleSelectionChanged_actualizaEstado() async {
+    func binding_demoToggleSelection_actualizaEstado() async {
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         }
-        await store.send(.demoToggleSelectionChanged(.lower)) {
+        await store.send(.binding(.set(\.demoToggleSelection, .lower))) {
             $0.demoToggleSelection = .lower
         }
-        await store.send(.demoToggleSelectionChanged(.upper)) {
+        await store.send(.binding(.set(\.demoToggleSelection, .upper))) {
             $0.demoToggleSelection = .upper
         }
     }

--- a/project.yml
+++ b/project.yml
@@ -18,6 +18,9 @@ packages:
   swift-composable-architecture:
     url: https://github.com/pointfreeco/swift-composable-architecture
     from: 1.16.0
+  swift-perception:
+    url: https://github.com/pointfreeco/swift-perception
+    from: 2.0.0
   AudioKit:
     url: https://github.com/AudioKit/AudioKit
     from: 5.6.0
@@ -41,6 +44,8 @@ targets:
     dependencies:
       - package: swift-composable-architecture
         product: ComposableArchitecture
+      - package: swift-perception
+        product: Perception
       - package: AudioKit
         product: AudioKit
 


### PR DESCRIPTION
## HU 2 — HUN-2 AcidToggle
- **Interruptor vertical** de dos posiciones (`AcidToggleSelection.upper / .lower`) con estética **metálica** alineada con AcidKnob.
- **Toque** en la pista alterna posición; animación **spring**; **háptica** ligera (configurable con `usesHaptics`).
- Etiquetas configurables (demo **SAW** / **SQR** como ondas).
- **Accesibilidad**: valor actual, acción nombrada "Alternar".
- **TCA**: `demoToggleSelection` + `.demoToggleSelectionChanged`; demo en `AppView` junto al knob.
- **Tests**: `AcidToggleSelection.toggled`, reducer en `AppFeatureTests`.

Cierra la issue **HU 2** al mergear si aplica.

Made with [Cursor](https://cursor.com)