### PR TITLE
HU 3: AcidButton (metálico, pulsado, acción al soltar)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,7 +42,7 @@ Serie lineal: **Oscilador (sierra/cuadrado)** → **Filtro ladder** (cutoff, res
 
 - La definición del target vive en **`project.yml`** ([XcodeGen](https://github.com/yonaskolb/XcodeGen)). Tras cambiar el YAML: `xcodegen generate` en la raíz del repo.
 - Abre **`AcidMe.xcodeproj`** en Xcode, deja que resuelva los paquetes (**File → Packages → Resolve Package Versions**) y compila el esquema **AcidMe** con destino **iPad** (simulador o dispositivo).
-- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables: **AcidKnob**, **AcidToggle**), `AcidMe/Resources` (Assets).
+- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables: **AcidKnob**, **AcidToggle**, **AcidButton**), `AcidMe/Resources` (Assets).
 
 ## Fuentes de verdad
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ Serie lineal: **Oscilador (sierra/cuadrado)** → **Filtro ladder** (cutoff, res
 
 - La definición del target vive en **`project.yml`** ([XcodeGen](https://github.com/yonaskolb/XcodeGen)). Tras cambiar el YAML: `xcodegen generate` en la raíz del repo.
 - Abre **`AcidMe.xcodeproj`** en Xcode, deja que resuelva los paquetes (**File → Packages → Resolve Package Versions**) y compila el esquema **AcidMe** con destino **iPad** (simulador o dispositivo).
+- Tests: **`AcidMe.xctestplan`** (referenciado por el esquema); **code coverage** del target **AcidMe** (definido en el plan y reflejado en `project.yml` vía XcodeGen).
 - Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables: **AcidKnob**, **AcidToggle**, **AcidButton**), `AcidMe/Resources` (Assets).
 
 ## Fuentes de verdad

--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */; };
 		05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72527E242323BE0F165CB92F /* AcidToggle.swift */; };
+		2AEDF4A5F7DDC8BD1B9746AE /* AcidButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */; };
 		6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */; };
 		86E3B0D5A89CC26FCF922CCB /* AudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = FE0F508000A1F0425A520A5C /* AudioKit */; };
 		882409673B5C11AF4F05E788 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1976140D3190C10989DF090E /* ContentView.swift */; };
@@ -36,6 +37,7 @@
 		0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggleSelectionTests.swift; sourceTree = "<group>"; };
 		1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnobMathTests.swift; sourceTree = "<group>"; };
 		1976140D3190C10989DF090E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButtonTests.swift; sourceTree = "<group>"; };
 		3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButton.swift; sourceTree = "<group>"; };
 		72527E242323BE0F165CB92F /* AcidToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggle.swift; sourceTree = "<group>"; };
 		85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnob.swift; sourceTree = "<group>"; };
@@ -72,6 +74,7 @@
 		43F95B9EF515F4D1E5404ECF /* AcidMeTests */ = {
 			isa = PBXGroup;
 			children = (
+				1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */,
 				1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */,
 				0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */,
 				A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */,
@@ -216,6 +219,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2AEDF4A5F7DDC8BD1B9746AE /* AcidButtonTests.swift in Sources */,
 				94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */,
 				97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */,
 				6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */,

--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */; };
 		86E3B0D5A89CC26FCF922CCB /* AudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = FE0F508000A1F0425A520A5C /* AudioKit */; };
 		882409673B5C11AF4F05E788 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1976140D3190C10989DF090E /* ContentView.swift */; };
+		8ACAE474A6C3C589DE2F194B /* AcidButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */; };
 		8F90CFBED1385137F71B1CE6 /* AppFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */; };
 		94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */; };
 		97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */; };
@@ -35,6 +36,7 @@
 		0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggleSelectionTests.swift; sourceTree = "<group>"; };
 		1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnobMathTests.swift; sourceTree = "<group>"; };
 		1976140D3190C10989DF090E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
+		3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButton.swift; sourceTree = "<group>"; };
 		72527E242323BE0F165CB92F /* AcidToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggle.swift; sourceTree = "<group>"; };
 		85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnob.swift; sourceTree = "<group>"; };
 		973DB5D629F27409804B1093 /* AcidMeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidMeApp.swift; sourceTree = "<group>"; };
@@ -126,6 +128,7 @@
 		FD110CAF6CFEEA729D033E88 /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */,
 				85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */,
 				72527E242323BE0F165CB92F /* AcidToggle.swift */,
 			);
@@ -223,6 +226,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8ACAE474A6C3C589DE2F194B /* AcidButton.swift in Sources */,
 				E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */,
 				CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */,
 				05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */,

--- a/AcidMe.xcodeproj/xcshareddata/xcschemes/AcidMe.xcscheme
+++ b/AcidMe.xcodeproj/xcshareddata/xcschemes/AcidMe.xcscheme
@@ -42,7 +42,14 @@
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "NO">
+      codeCoverageEnabled = "YES"
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <TestPlans>
+         <TestPlanReference
+            default = "YES"
+            reference = "container:AcidMe.xctestplan">
+         </TestPlanReference>
+      </TestPlans>
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -67,6 +74,15 @@
       </Testables>
       <CommandLineArguments>
       </CommandLineArguments>
+      <CodeCoverageTargets>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "C7BD1A3BA674C350164FE980"
+            BuildableName = "AcidMe.app"
+            BlueprintName = "AcidMe"
+            ReferencedContainer = "container:AcidMe.xcodeproj">
+         </BuildableReference>
+      </CodeCoverageTargets>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"

--- a/AcidMe.xctestplan
+++ b/AcidMe.xctestplan
@@ -1,0 +1,39 @@
+{
+  "configurations" : [
+    {
+      "id" : "DE13BF63-0D12-412F-8FD6-7531B2DD3AA6",
+      "name" : "Configuration 1",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "codeCoverage" : {
+      "targets" : [
+        {
+          "containerPath" : "container:AcidMe.xcodeproj",
+          "identifier" : "C7BD1A3BA674C350164FE980",
+          "name" : "AcidMe"
+        }
+      ]
+    },
+    "performanceAntipatternCheckerEnabled" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:AcidMe.xcodeproj",
+      "identifier" : "C7BD1A3BA674C350164FE980",
+      "name" : "AcidMe"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : false,
+      "target" : {
+        "containerPath" : "container:AcidMe.xcodeproj",
+        "identifier" : "6F9828A43DD366C65B76633D",
+        "name" : "AcidMeTests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -11,10 +11,22 @@ struct AppView: View {
             VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 2 · AcidKnob + AcidToggle horizontal (toque → A/B)")
+                Text("HU 3 · Knob + Toggle + AcidButton (acción al soltar)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
+
+                HStack(spacing: 16) {
+                    AcidButton(title: "PLAY", systemImage: "play.fill") {
+                        store.send(.demoPlayButtonReleased)
+                    }
+                    AcidButton(title: "CLEAR", systemImage: "trash") {
+                        store.send(.demoClearButtonReleased)
+                    }
+                    Text("PLAY \(store.demoPlayButtonReleaseCount) · CLEAR \(store.demoClearButtonReleaseCount)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                }
 
                 HStack(alignment: .center, spacing: 48) {
                     VStack(spacing: 8) {

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -10,10 +10,15 @@ struct AppFeature {
         var demoKnobValue: Double = 0.35
         /// Selección del AcidToggle (HU 2); p. ej. onda superior/inferior o FX.
         var demoToggleSelection: AcidToggleSelection = .upper
+        /// Contadores de suelta en botones demo (HU 3).
+        var demoPlayButtonReleaseCount: Int = 0
+        var demoClearButtonReleaseCount: Int = 0
     }
 
     enum Action: BindableAction, Equatable {
         case binding(BindingAction<State>)
+        case demoPlayButtonReleased
+        case demoClearButtonReleased
     }
 
     var body: some ReducerOf<Self> {
@@ -23,6 +28,13 @@ struct AppFeature {
             case .binding:
                 // Tras cualquier binding, mantiene el knob en 0…1 (p. ej. arrastre del AcidKnob).
                 state.demoKnobValue = min(1, max(0, state.demoKnobValue))
+                return .none
+            case .demoPlayButtonReleased:
+                state.demoPlayButtonReleaseCount += 1
+                return .none
+            case .demoClearButtonReleased:
+                state.demoClearButtonReleaseCount += 1
+                state.demoKnobValue = 0
                 return .none
             }
         }

--- a/AcidMe/Features/Components/AcidButton.swift
+++ b/AcidMe/Features/Components/AcidButton.swift
@@ -34,10 +34,11 @@ struct AcidMetalButtonStyle: ButtonStyle {
     }
 
     private func metalFill(pressed: Bool) -> LinearGradient {
+        // Metal más oscuro que antes para que el texto claro contraste bien.
         LinearGradient(
             colors: pressed
-                ? [Color(white: 0.32), Color(white: 0.22), Color(white: 0.27)]
-                : [Color(white: 0.42), Color(white: 0.30), Color(white: 0.36)],
+                ? [Color(white: 0.28), Color(white: 0.18), Color(white: 0.22)]
+                : [Color(white: 0.36), Color(white: 0.24), Color(white: 0.30)],
             startPoint: .top,
             endPoint: .bottom
         )
@@ -47,9 +48,6 @@ struct AcidMetalButtonStyle: ButtonStyle {
 // MARK: - Vista
 
 struct AcidButton: View {
-    /// Color de etiqueta e icono (legible sobre el metal del estilo).
-    static let labelColor = Color(red: 0.04, green: 0.04, blue: 0.05)
-
     var title: String
     var systemImage: String?
     var usesHaptics: Bool = true
@@ -71,11 +69,21 @@ struct AcidButton: View {
                 Text(title)
                     .font(.subheadline.weight(.bold))
             }
-            // Casi negro sobre metal gris: contraste alto (antes ~12% gris sobre ~45% gris).
-            .foregroundStyle(AcidButton.labelColor)
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [
+                        Color(red: 1, green: 0.99, blue: 0.95),
+                        Color(red: 0.94, green: 0.90, blue: 0.82),
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            // Contorno suave para leer sobre zonas claras del bisel metálico.
+            .shadow(color: .black.opacity(0.55), radius: 0, x: 0, y: 1)
         }
         .buttonStyle(AcidMetalButtonStyle())
-        .tint(AcidButton.labelColor)
+        .tint(.white)
     }
 }
 

--- a/AcidMe/Features/Components/AcidButton.swift
+++ b/AcidMe/Features/Components/AcidButton.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Estilo
+
+/// Botón metálico: aspecto “pulsado” mientras el dedo está abajo; la acción de SwiftUI se ejecuta al **soltar** dentro del área (Gherkin HU 3).
+struct AcidMetalButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .padding(.horizontal, 18)
+            .padding(.vertical, 12)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(metalFill(pressed: configuration.isPressed))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [
+                                Color(white: configuration.isPressed ? 0.35 : 0.55),
+                                Color(white: 0.2),
+                                Color(white: configuration.isPressed ? 0.3 : 0.45),
+                            ],
+                            startPoint: .topLeading,
+                            endPoint: .bottomTrailing
+                        ),
+                        lineWidth: configuration.isPressed ? 1.5 : 2
+                    )
+            )
+            .shadow(color: .black.opacity(configuration.isPressed ? 0.12 : 0.28), radius: configuration.isPressed ? 1 : 3, y: configuration.isPressed ? 0 : 2)
+            .scaleEffect(configuration.isPressed ? 0.96 : 1)
+            .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+    }
+
+    private func metalFill(pressed: Bool) -> LinearGradient {
+        LinearGradient(
+            colors: pressed
+                ? [Color(white: 0.36), Color(white: 0.28), Color(white: 0.32)]
+                : [Color(white: 0.5), Color(white: 0.38), Color(white: 0.44)],
+            startPoint: .top,
+            endPoint: .bottom
+        )
+    }
+}
+
+// MARK: - Vista
+
+struct AcidButton: View {
+    var title: String
+    var systemImage: String?
+    var usesHaptics: Bool = true
+    let action: () -> Void
+
+    var body: some View {
+        Button {
+            if usesHaptics {
+                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            }
+            action()
+        } label: {
+            HStack(spacing: 8) {
+                if let systemImage {
+                    Image(systemName: systemImage)
+                        .font(.subheadline.weight(.bold))
+                }
+                Text(title)
+                    .font(.subheadline.weight(.bold))
+            }
+            .foregroundStyle(Color(white: 0.12))
+        }
+        .buttonStyle(AcidMetalButtonStyle())
+    }
+}
+
+#Preview("AcidButton") {
+    VStack(spacing: 16) {
+        AcidButton(title: "PLAY", systemImage: "play.fill") {}
+        AcidButton(title: "CLEAR", systemImage: "trash") {}
+    }
+    .padding()
+    .background(Color(red: 0.95, green: 0.85, blue: 0.15).opacity(0.2))
+}

--- a/AcidMe/Features/Components/AcidButton.swift
+++ b/AcidMe/Features/Components/AcidButton.swift
@@ -1,6 +1,36 @@
 import SwiftUI
 import UIKit
 
+// MARK: - Valores testeables (contraste texto / metal)
+
+enum AcidButtonStyleMath {
+    /// Stops `Color(white:)` del relleno metálico (sin pulsar / pulsado).
+    static let metalLuminancesUnpressed: [Double] = [0.36, 0.24, 0.30]
+    static let metalLuminancesPressed: [Double] = [0.28, 0.18, 0.22]
+
+    static func averageMetalLuminance(pressed: Bool) -> Double {
+        let xs = pressed ? metalLuminancesPressed : metalLuminancesUnpressed
+        return xs.reduce(0, +) / Double(xs.count)
+    }
+
+    /// RGB del gradiente de etiqueta (sRGB 0…1).
+    static let labelTopRGB = (r: 1.0, g: 0.99, b: 0.95)
+    static let labelBottomRGB = (r: 0.94, g: 0.90, b: 0.82)
+
+    private static func sdrLuminance(_ rgb: (r: Double, g: Double, b: Double)) -> Double {
+        0.2126 * rgb.r + 0.7152 * rgb.g + 0.0722 * rgb.b
+    }
+
+    static func averageLabelLuminance() -> Double {
+        (sdrLuminance(labelTopRGB) + sdrLuminance(labelBottomRGB)) / 2
+    }
+
+    /// Regresión: el texto claro debe destacar claramente sobre el metal.
+    static func labelIsBrighterThanMetal(pressed: Bool, margin: Double = 0.22) -> Bool {
+        averageLabelLuminance() > averageMetalLuminance(pressed: pressed) + margin
+    }
+}
+
 // MARK: - Estilo
 
 /// Botón metálico: aspecto “pulsado” mientras el dedo está abajo; la acción de SwiftUI se ejecuta al **soltar** dentro del área (Gherkin HU 3).
@@ -34,11 +64,11 @@ struct AcidMetalButtonStyle: ButtonStyle {
     }
 
     private func metalFill(pressed: Bool) -> LinearGradient {
-        // Metal más oscuro que antes para que el texto claro contraste bien.
-        LinearGradient(
-            colors: pressed
-                ? [Color(white: 0.28), Color(white: 0.18), Color(white: 0.22)]
-                : [Color(white: 0.36), Color(white: 0.24), Color(white: 0.30)],
+        let stops = pressed
+            ? AcidButtonStyleMath.metalLuminancesPressed
+            : AcidButtonStyleMath.metalLuminancesUnpressed
+        return LinearGradient(
+            colors: stops.map { Color(white: $0) },
             startPoint: .top,
             endPoint: .bottom
         )
@@ -72,8 +102,16 @@ struct AcidButton: View {
             .foregroundStyle(
                 LinearGradient(
                     colors: [
-                        Color(red: 1, green: 0.99, blue: 0.95),
-                        Color(red: 0.94, green: 0.90, blue: 0.82),
+                        Color(
+                            red: AcidButtonStyleMath.labelTopRGB.r,
+                            green: AcidButtonStyleMath.labelTopRGB.g,
+                            blue: AcidButtonStyleMath.labelTopRGB.b
+                        ),
+                        Color(
+                            red: AcidButtonStyleMath.labelBottomRGB.r,
+                            green: AcidButtonStyleMath.labelBottomRGB.g,
+                            blue: AcidButtonStyleMath.labelBottomRGB.b
+                        ),
                     ],
                     startPoint: .top,
                     endPoint: .bottom

--- a/AcidMe/Features/Components/AcidButton.swift
+++ b/AcidMe/Features/Components/AcidButton.swift
@@ -36,8 +36,8 @@ struct AcidMetalButtonStyle: ButtonStyle {
     private func metalFill(pressed: Bool) -> LinearGradient {
         LinearGradient(
             colors: pressed
-                ? [Color(white: 0.36), Color(white: 0.28), Color(white: 0.32)]
-                : [Color(white: 0.5), Color(white: 0.38), Color(white: 0.44)],
+                ? [Color(white: 0.32), Color(white: 0.22), Color(white: 0.27)]
+                : [Color(white: 0.42), Color(white: 0.30), Color(white: 0.36)],
             startPoint: .top,
             endPoint: .bottom
         )
@@ -47,6 +47,9 @@ struct AcidMetalButtonStyle: ButtonStyle {
 // MARK: - Vista
 
 struct AcidButton: View {
+    /// Color de etiqueta e icono (legible sobre el metal del estilo).
+    static let labelColor = Color(red: 0.04, green: 0.04, blue: 0.05)
+
     var title: String
     var systemImage: String?
     var usesHaptics: Bool = true
@@ -63,13 +66,16 @@ struct AcidButton: View {
                 if let systemImage {
                     Image(systemName: systemImage)
                         .font(.subheadline.weight(.bold))
+                        .symbolRenderingMode(.monochrome)
                 }
                 Text(title)
                     .font(.subheadline.weight(.bold))
             }
-            .foregroundStyle(Color(white: 0.12))
+            // Casi negro sobre metal gris: contraste alto (antes ~12% gris sobre ~45% gris).
+            .foregroundStyle(AcidButton.labelColor)
         }
         .buttonStyle(AcidMetalButtonStyle())
+        .tint(AcidButton.labelColor)
     }
 }
 

--- a/AcidMeTests/AcidButtonTests.swift
+++ b/AcidMeTests/AcidButtonTests.swift
@@ -1,0 +1,28 @@
+import Testing
+
+@testable import AcidMe
+
+@Suite("AcidButtonStyleMath")
+struct AcidButtonStyleMathTests {
+    @Test
+    func metalPromedioMasOscuroCuandoEstaPulsado() {
+        let up = AcidButtonStyleMath.averageMetalLuminance(pressed: false)
+        let down = AcidButtonStyleMath.averageMetalLuminance(pressed: true)
+        #expect(down < up)
+    }
+
+    @Test
+    func etiquetaEsMasLuminosaQueElMetal_sinPulsar() {
+        #expect(AcidButtonStyleMath.labelIsBrighterThanMetal(pressed: false))
+    }
+
+    @Test
+    func etiquetaEsMasLuminosaQueElMetal_pulsado() {
+        #expect(AcidButtonStyleMath.labelIsBrighterThanMetal(pressed: true))
+    }
+
+    @Test
+    func luminanciaMediaEtiquetaEsAlta() {
+        #expect(AcidButtonStyleMath.averageLabelLuminance() > 0.88)
+    }
+}

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -39,4 +39,25 @@ struct AppFeatureTests {
             $0.demoToggleSelection = .upper
         }
     }
+
+    @Test
+    func demoPlayButtonReleased_incrementaContador() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+        await store.send(.demoPlayButtonReleased) {
+            $0.demoPlayButtonReleaseCount = 1
+        }
+    }
+
+    @Test
+    func demoClearButtonReleased_incrementaYReseteaKnob() async {
+        let store = TestStore(initialState: AppFeature.State(demoKnobValue: 0.8)) {
+            AppFeature()
+        }
+        await store.send(.demoClearButtonReleased) {
+            $0.demoClearButtonReleaseCount = 1
+            $0.demoKnobValue = 0
+        }
+    }
 }

--- a/project.yml
+++ b/project.yml
@@ -71,3 +71,9 @@ schemes:
     test:
       targets:
         - AcidMeTests
+      testPlans:
+        - path: AcidMe.xctestplan
+          default: true
+      gatherCoverageData: true
+      coverageTargets:
+        - AcidMe


### PR DESCRIPTION
## HU 3 — HUN-3 AcidButton
- `AcidMetalButtonStyle` + `AcidButton`: aspecto metálico, estado **pulsado** con `ButtonStyle`, acción de `Button` al **soltar** (comportamiento estándar SwiftUI).
- Háptica **medium** al completar la acción (soltar).
- Demo **PLAY** / **CLEAR** en `AppView`; contadores en estado; **CLEAR** pone el knob demo a **0**.
- Tests del reducer para ambas acciones.

### Proyecto GitHub
HU 0, HU 1 y HU 2 marcadas como **Done** en el tablero AcidMe!.

Cierra la issue **HU 3** al mergear si aplica.

Made with [Cursor](https://cursor.com)