### PR TITLE
feat(HU5): teclado Acid con selector de octava y tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,7 +43,7 @@ Serie lineal: **Oscilador (sierra/cuadrado)** → **Filtro ladder** (cutoff, res
 - La definición del target vive en **`project.yml`** ([XcodeGen](https://github.com/yonaskolb/XcodeGen)). Tras cambiar el YAML: `xcodegen generate` en la raíz del repo.
 - Abre **`AcidMe.xcodeproj`** en Xcode, deja que resuelva los paquetes (**File → Packages → Resolve Package Versions**) y compila el esquema **AcidMe** con destino **iPad** (simulador o dispositivo).
 - Tests: **`AcidMe.xctestplan`** (referenciado por el esquema); **code coverage** del target **AcidMe** (definido en el plan y reflejado en `project.yml` vía XcodeGen).
-- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables: **AcidKnob**, **AcidToggle**, **AcidButton**, **AcidPianoRoll** 12 filas, 16 pasos por compás, 1–4 compases, notas con longitud), `AcidMe/Resources` (Assets).
+- Estructura de código: `AcidMe/App` (entrada SwiftUI), `AcidMe/Core` (TCA raíz, enganche AudioKit), `AcidMe/Features/Components` (controles reutilizables: **AcidKnob**, **AcidToggle**, **AcidButton**, **AcidPianoRoll**, **AcidKeyboard** una octava + octava ±3), `AcidMe/Resources` (Assets).
 
 ## Fuentes de verdad
 

--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -19,9 +19,11 @@
 		94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */; };
 		97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */; };
 		9B6E7E9AD60C9F99D2E54C58 /* ComposableArchitecture in Frameworks */ = {isa = PBXBuildFile; productRef = EC0B52AD9704E1B22B0A1397 /* ComposableArchitecture */; };
+		9F47412D5D333BE53A511FD5 /* AcidKeyboardMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E666C9AB4E64FDCD9675B910 /* AcidKeyboardMathTests.swift */; };
 		C8AD1F78E343A5FD3FDB6E49 /* AcidPianoRoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E8C27A722E097E29D34EF8 /* AcidPianoRoll.swift */; };
 		CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973DB5D629F27409804B1093 /* AcidMeApp.swift */; };
 		E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */; };
+		E73AA2F81B89757051283D57 /* AcidKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917F0F3E18EC986870855A06 /* AcidKeyboard.swift */; };
 		FDFBC7AC139584F4B17B6589 /* Perception in Frameworks */ = {isa = PBXBuildFile; productRef = 2D0348C6BA11532A7A728F65 /* Perception */; };
 /* End PBXBuildFile section */
 
@@ -44,6 +46,7 @@
 		3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButton.swift; sourceTree = "<group>"; };
 		72527E242323BE0F165CB92F /* AcidToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggle.swift; sourceTree = "<group>"; };
 		85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnob.swift; sourceTree = "<group>"; };
+		917F0F3E18EC986870855A06 /* AcidKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKeyboard.swift; sourceTree = "<group>"; };
 		973DB5D629F27409804B1093 /* AcidMeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidMeApp.swift; sourceTree = "<group>"; };
 		A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureTests.swift; sourceTree = "<group>"; };
 		C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioKitBootstrap.swift; sourceTree = "<group>"; };
@@ -51,6 +54,7 @@
 		D12FA876D6E8CEE040984562 /* AcidMeTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AcidMeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3B5A66BD50A60974610B2A2 /* AcidMe.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AcidMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		E2E8C27A722E097E29D34EF8 /* AcidPianoRoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidPianoRoll.swift; sourceTree = "<group>"; };
+		E666C9AB4E64FDCD9675B910 /* AcidKeyboardMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKeyboardMathTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -79,6 +83,7 @@
 			isa = PBXGroup;
 			children = (
 				1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */,
+				E666C9AB4E64FDCD9675B910 /* AcidKeyboardMathTests.swift */,
 				1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */,
 				0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */,
 				A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */,
@@ -137,6 +142,7 @@
 			isa = PBXGroup;
 			children = (
 				3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */,
+				917F0F3E18EC986870855A06 /* AcidKeyboard.swift */,
 				85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */,
 				E2E8C27A722E097E29D34EF8 /* AcidPianoRoll.swift */,
 				72527E242323BE0F165CB92F /* AcidToggle.swift */,
@@ -226,6 +232,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				2AEDF4A5F7DDC8BD1B9746AE /* AcidButtonTests.swift in Sources */,
+				9F47412D5D333BE53A511FD5 /* AcidKeyboardMathTests.swift in Sources */,
 				94C22E137E1F1ABC8FACA7FB /* AcidKnobMathTests.swift in Sources */,
 				97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */,
 				6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */,
@@ -238,6 +245,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				8ACAE474A6C3C589DE2F194B /* AcidButton.swift in Sources */,
+				E73AA2F81B89757051283D57 /* AcidKeyboard.swift in Sources */,
 				E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */,
 				CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */,
 				C8AD1F78E343A5FD3FDB6E49 /* AcidPianoRoll.swift in Sources */,

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -11,7 +11,7 @@ struct AppView: View {
             VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 4 · Piano roll (rejilla fija, fracciones de compás) + controles anteriores")
+                Text("HU 4–5 · Piano roll + AcidKeyboard (Note On + Hz) + controles anteriores")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -30,6 +30,21 @@ struct AppView: View {
                     }
                 )
                 .padding(.horizontal, 8)
+
+                AcidKeyboard(
+                    octaveOffset: store.keyboardOctaveOffset,
+                    pressedMidiNotes: store.keyboardPressedMidiNotes,
+                    onOctaveOffsetChange: { store.send(.keyboardOctaveOffsetChanged($0)) },
+                    onNoteOn: { midi, hz in store.send(.keyboardNoteOn(midiNote: midi, frequencyHz: hz)) },
+                    onNoteOff: { store.send(.keyboardNoteOff(midiNote: $0)) }
+                )
+                .padding(.horizontal, 8)
+
+                if let last = store.keyboardLastNoteOn {
+                    Text("Último Note On: MIDI \(last.midiNote) · \(String(format: "%.2f", last.frequencyHz)) Hz")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(.tertiary)
+                }
 
                 HStack(spacing: 16) {
                     AcidButton(title: "PLAY", systemImage: "play.fill") {

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -6,6 +6,19 @@ import Foundation
 struct AppFeature {
     @ObservableState
     struct State: Equatable {
+        static func == (lhs: AppFeature.State, rhs: AppFeature.State) -> Bool {
+            return lhs.demoKnobValue == rhs.demoKnobValue
+            && lhs.demoToggleSelection == rhs.demoToggleSelection
+            && lhs.demoPlayButtonReleaseCount == rhs.demoPlayButtonReleaseCount
+            && lhs.demoClearButtonReleaseCount == rhs.demoClearButtonReleaseCount
+            && lhs.pianoRollGridSteps == rhs.pianoRollGridSteps
+            && lhs.pianoRollNotes == rhs.pianoRollNotes
+            && lhs.keyboardOctaveOffset == rhs.keyboardOctaveOffset
+            && lhs.keyboardPressedMidiNotes == rhs.keyboardPressedMidiNotes
+            && lhs.keyboardLastNoteOn?.midiNote == rhs.keyboardLastNoteOn?.midiNote
+            && lhs.keyboardLastNoteOn?.frequencyHz == rhs.keyboardLastNoteOn?.frequencyHz
+        }
+
         /// Valor de demostración del AcidKnob (HU 1); más adelante se sustituirá por parámetros reales de síntesis.
         var demoKnobValue: Double = 0.35
         /// Selección del AcidToggle (HU 2); p. ej. onda superior/inferior o FX.

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -16,6 +16,11 @@ struct AppFeature {
         /// Piano roll: hasta 16 pasos (1 compás); 4/8 = fracciones del compás (HU 4).
         var pianoRollGridSteps: Int = 16
         var pianoRollNotes: [PianoRollNote] = []
+        /// Teclado musical (HU 5): octava ±3 respecto a C4; notas actualmente pulsadas.
+        var keyboardOctaveOffset: Int = 0
+        var keyboardPressedMidiNotes: Set<Int> = []
+        /// Último Note On (demo hasta AudioClient en HU 6).
+        var keyboardLastNoteOn: (midiNote: Int, frequencyHz: Double)?
     }
 
     enum Action: BindableAction, Equatable {
@@ -27,6 +32,9 @@ struct AppFeature {
         case pianoRollStepsPainted(row: Int, startStep: Int, endStep: Int)
         case pianoRollNoteRemoved(UUID)
         case pianoRollNoteResized(id: UUID, startStep: Int, length: Int)
+        case keyboardOctaveOffsetChanged(Int)
+        case keyboardNoteOn(midiNote: Int, frequencyHz: Double)
+        case keyboardNoteOff(midiNote: Int)
     }
 
     var body: some ReducerOf<Self> {
@@ -84,6 +92,19 @@ struct AppFeature {
                     newLength: length,
                     stepCount: steps
                 )
+                return .none
+            case let .keyboardOctaveOffsetChanged(raw):
+                state.keyboardOctaveOffset = max(
+                    AcidKeyboardMath.minOctaveOffset,
+                    min(AcidKeyboardMath.maxOctaveOffset, raw)
+                )
+                return .none
+            case let .keyboardNoteOn(midiNote, frequencyHz):
+                state.keyboardPressedMidiNotes.insert(midiNote)
+                state.keyboardLastNoteOn = (midiNote, frequencyHz)
+                return .none
+            case let .keyboardNoteOff(midiNote):
+                state.keyboardPressedMidiNotes.remove(midiNote)
                 return .none
             }
         }

--- a/AcidMe/Features/Components/AcidButton.swift
+++ b/AcidMe/Features/Components/AcidButton.swift
@@ -35,10 +35,13 @@ enum AcidButtonStyleMath {
 
 /// Botón metálico: aspecto “pulsado” mientras el dedo está abajo; la acción de SwiftUI se ejecuta al **soltar** dentro del área (Gherkin HU 3).
 struct AcidMetalButtonStyle: ButtonStyle {
+    var horizontalPadding: CGFloat = 18
+    var verticalPadding: CGFloat = 12
+
     func makeBody(configuration: Configuration) -> some View {
         configuration.label
-            .padding(.horizontal, 18)
-            .padding(.vertical, 12)
+            .padding(.horizontal, horizontalPadding)
+            .padding(.vertical, verticalPadding)
             .background(
                 RoundedRectangle(cornerRadius: 8, style: .continuous)
                     .fill(metalFill(pressed: configuration.isPressed))

--- a/AcidMe/Features/Components/AcidKeyboard.swift
+++ b/AcidMe/Features/Components/AcidKeyboard.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import UIKit
 
 // MARK: - Matemática (testeable)
 
@@ -30,6 +31,20 @@ enum AcidKeyboardMath {
     static let blackKeyWhiteSlotIndices: [(Int, Int)] = [
         (0, 1), (1, 2), (3, 4), (4, 5), (5, 6),
     ]
+
+    /// Nombre de la nota **do** inferior del teclado (p. ej. MIDI 60 → \"C4\").
+    static func rootOctaveScientificName(rootMidi: Int) -> String {
+        let m = min(127, max(0, rootMidi))
+        let octaveNumber = m / 12 - 1
+        return "C\(octaveNumber)"
+    }
+
+    /// Texto de desplazamiento de octava respecto a C4: `0`, `+1`, `-2`, …
+    static func octaveOffsetDisplay(offset: Int) -> String {
+        if offset == 0 { return "0" }
+        if offset > 0 { return "+\(offset)" }
+        return "\(offset)"
+    }
 }
 
 // MARK: - Tecla
@@ -139,24 +154,7 @@ struct AcidKeyboard: View {
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.secondary)
                 Spacer()
-                HStack(spacing: 8) {
-                    Text("Octava")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                    Stepper(
-                        value: Binding(
-                            get: { octaveOffset },
-                            set: { onOctaveOffsetChange($0) }
-                        ),
-                        in: AcidKeyboardMath.minOctaveOffset ... AcidKeyboardMath.maxOctaveOffset,
-                        label: {
-                            Text(octaveLabel)
-                                .font(.caption.monospacedDigit())
-                                .foregroundStyle(.secondary)
-                                .frame(minWidth: 72, alignment: .trailing)
-                        }
-                    )
-                }
+                octaveSelectorRow
             }
 
             GeometryReader { geo in
@@ -215,13 +213,70 @@ struct AcidKeyboard: View {
             .frame(height: keyboardHeight)
         }
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Teclado musical, una octava, octava \(octaveLabel)")
+        .accessibilityLabel(
+            "Teclado musical, una octava, desplazamiento de octava \(AcidKeyboardMath.octaveOffsetDisplay(offset: octaveOffset))"
+        )
     }
 
-    private var octaveLabel: String {
-        if octaveOffset == 0 { return "C4 (±0)" }
-        let sign = octaveOffset > 0 ? "+" : ""
-        return "\(sign)\(octaveOffset)"
+    private var octaveSelectorRow: some View {
+        HStack(spacing: 14) {
+            Button {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                onOctaveOffsetChange(octaveOffset - 1)
+            } label: {
+                Text("-")
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .frame(minWidth: 22, minHeight: 22)
+                    .foregroundStyle(acidMetalLabelGradient)
+                    .shadow(color: .black.opacity(0.55), radius: 0, x: 0, y: 1)
+            }
+            .buttonStyle(AcidMetalButtonStyle(horizontalPadding: 14, verticalPadding: 10))
+            .disabled(octaveOffset <= AcidKeyboardMath.minOctaveOffset)
+            .opacity(octaveOffset <= AcidKeyboardMath.minOctaveOffset ? 0.42 : 1)
+            .accessibilityLabel("Bajar una octava")
+
+            Text(AcidKeyboardMath.octaveOffsetDisplay(offset: octaveOffset))
+                .font(.system(size: 22, weight: .bold, design: .rounded))
+                .monospacedDigit()
+                .foregroundStyle(Color(white: 0.12))
+                .frame(minWidth: 56)
+                .multilineTextAlignment(.center)
+                .accessibilityLabel("Octava \(AcidKeyboardMath.octaveOffsetDisplay(offset: octaveOffset))")
+
+            Button {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                onOctaveOffsetChange(octaveOffset + 1)
+            } label: {
+                Text("+")
+                    .font(.system(size: 22, weight: .bold, design: .rounded))
+                    .frame(minWidth: 22, minHeight: 22)
+                    .foregroundStyle(acidMetalLabelGradient)
+                    .shadow(color: .black.opacity(0.55), radius: 0, x: 0, y: 1)
+            }
+            .buttonStyle(AcidMetalButtonStyle(horizontalPadding: 14, verticalPadding: 10))
+            .disabled(octaveOffset >= AcidKeyboardMath.maxOctaveOffset)
+            .opacity(octaveOffset >= AcidKeyboardMath.maxOctaveOffset ? 0.42 : 1)
+            .accessibilityLabel("Subir una octava")
+        }
+    }
+
+    private var acidMetalLabelGradient: LinearGradient {
+        LinearGradient(
+            colors: [
+                Color(
+                    red: AcidButtonStyleMath.labelTopRGB.r,
+                    green: AcidButtonStyleMath.labelTopRGB.g,
+                    blue: AcidButtonStyleMath.labelTopRGB.b
+                ),
+                Color(
+                    red: AcidButtonStyleMath.labelBottomRGB.r,
+                    green: AcidButtonStyleMath.labelBottomRGB.g,
+                    blue: AcidButtonStyleMath.labelBottomRGB.b
+                ),
+            ],
+            startPoint: .top,
+            endPoint: .bottom
+        )
     }
 
     private func whiteLabel(semitone: Int) -> String {

--- a/AcidMe/Features/Components/AcidKeyboard.swift
+++ b/AcidMe/Features/Components/AcidKeyboard.swift
@@ -1,0 +1,260 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Matemática (testeable)
+
+enum AcidKeyboardMath {
+    /// Desplazamiento de octava respecto a do central (C4 = MIDI 60). RF-203: ±3 octavas.
+    static let minOctaveOffset = -3
+    static let maxOctaveOffset = 3
+
+    /// MIDI de la nota C inferior del teclado de una octava (12 semitonos: C…B).
+    static func rootMidi(octaveOffset: Int) -> Int {
+        let o = max(minOctaveOffset, min(maxOctaveOffset, octaveOffset))
+        let base = 60 + o * 12
+        return min(127 - 11, max(0, base))
+    }
+
+    /// Frecuencia en Hz (temperamento igual, A4 = 440 Hz).
+    static func frequencyHz(midiNote: Int) -> Double {
+        let n = Double(min(127, max(0, midiNote)))
+        return 440.0 * pow(2.0, (n - 69.0) / 12.0)
+    }
+
+    /// Semitonos de las teclas blancas desde la raíz (do mayor).
+    static let whiteKeySemitonesFromRoot = [0, 2, 4, 5, 7, 9, 11]
+    /// Semitonos de las teclas negras (sostenidos) en la misma octava.
+    static let blackKeySemitonesFromRoot = [1, 3, 6, 8, 10]
+
+    /// Pares (índice tecla blanca izq., der.) bajo los que se dibuja cada negra.
+    static let blackKeyWhiteSlotIndices: [(Int, Int)] = [
+        (0, 1), (1, 2), (3, 4), (4, 5), (5, 6),
+    ]
+}
+
+// MARK: - Tecla
+
+private struct AcidKeyboardKey: View {
+    let midiNote: Int
+    let label: String
+    let isBlack: Bool
+    let isPressed: Bool
+    let whiteWidth: CGFloat
+    let whiteHeight: CGFloat
+    let gap: CGFloat
+    let onNoteOn: () -> Void
+    let onNoteOff: () -> Void
+
+    private var blackWidth: CGFloat { max(18, whiteWidth * 0.58) }
+    private var blackHeight: CGFloat { whiteHeight * 0.58 }
+
+    var body: some View {
+        Group {
+            if isBlack {
+                keyShape(
+                    width: blackWidth,
+                    height: blackHeight,
+                    corner: 4,
+                    fillTop: Color(white: isPressed ? 0.22 : 0.12),
+                    fillBottom: Color(white: isPressed ? 0.08 : 0.04),
+                    stroke: Color(white: 0.38)
+                )
+            } else {
+                keyShape(
+                    width: whiteWidth,
+                    height: whiteHeight,
+                    corner: 5,
+                    fillTop: Color(white: isPressed ? 0.92 : 0.99),
+                    fillBottom: Color(white: isPressed ? 0.72 : 0.82),
+                    stroke: Color(white: 0.42)
+                )
+                .overlay(alignment: .bottom) {
+                    Text(label)
+                        .font(.system(size: 10, weight: .semibold, design: .rounded))
+                        .foregroundStyle(Color(white: 0.2))
+                        .padding(.bottom, 6)
+                }
+            }
+        }
+        .contentShape(Rectangle())
+        .onLongPressGesture(
+            minimumDuration: 0,
+            maximumDistance: .infinity,
+            pressing: { pressing in
+                if pressing {
+                    onNoteOn()
+                } else {
+                    onNoteOff()
+                }
+            },
+            perform: {}
+        )
+        .accessibilityLabel("\(label), MIDI \(midiNote)")
+        .accessibilityAddTraits(.isButton)
+    }
+
+    @ViewBuilder
+    private func keyShape(
+        width: CGFloat,
+        height: CGFloat,
+        corner: CGFloat,
+        fillTop: Color,
+        fillBottom: Color,
+        stroke: Color
+    ) -> some View {
+        RoundedRectangle(cornerRadius: corner, style: .continuous)
+            .fill(
+                LinearGradient(
+                    colors: [fillTop, fillBottom],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: corner, style: .continuous)
+                    .strokeBorder(stroke, lineWidth: isBlack ? 0.75 : 1)
+            )
+            .frame(width: width, height: height)
+    }
+}
+
+// MARK: - Vista principal
+
+struct AcidKeyboard: View {
+    var octaveOffset: Int
+    var pressedMidiNotes: Set<Int>
+    var onOctaveOffsetChange: (Int) -> Void
+    var onNoteOn: (Int, Double) -> Void
+    var onNoteOff: (Int) -> Void
+
+    private let keyGap: CGFloat = 3
+    private let keyboardHeight: CGFloat = 160
+
+    private var rootMidi: Int { AcidKeyboardMath.rootMidi(octaveOffset: octaveOffset) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Teclado")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer()
+                HStack(spacing: 8) {
+                    Text("Octava")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    Stepper(
+                        value: Binding(
+                            get: { octaveOffset },
+                            set: { onOctaveOffsetChange($0) }
+                        ),
+                        in: AcidKeyboardMath.minOctaveOffset ... AcidKeyboardMath.maxOctaveOffset,
+                        label: {
+                            Text(octaveLabel)
+                                .font(.caption.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .frame(minWidth: 72, alignment: .trailing)
+                        }
+                    )
+                }
+            }
+
+            GeometryReader { geo in
+                let w = geo.size.width
+                let whiteCount = 7
+                let totalGaps = keyGap * CGFloat(whiteCount - 1)
+                let whiteW = max(24, (w - totalGaps) / CGFloat(whiteCount))
+                let whiteH = keyboardHeight
+
+                ZStack(alignment: .topLeading) {
+                    HStack(spacing: keyGap) {
+                        ForEach(Array(AcidKeyboardMath.whiteKeySemitonesFromRoot.enumerated()), id: \.offset) { _, semi in
+                            let midi = rootMidi + semi
+                            AcidKeyboardKey(
+                                midiNote: midi,
+                                label: whiteLabel(semitone: semi),
+                                isBlack: false,
+                                isPressed: pressedMidiNotes.contains(midi),
+                                whiteWidth: whiteW,
+                                whiteHeight: whiteH,
+                                gap: keyGap,
+                                onNoteOn: {
+                                    onNoteOn(midi, AcidKeyboardMath.frequencyHz(midiNote: midi))
+                                },
+                                onNoteOff: { onNoteOff(midi) }
+                            )
+                        }
+                    }
+
+                    ForEach(Array(AcidKeyboardMath.blackKeySemitonesFromRoot.enumerated()), id: \.offset) { idx, semi in
+                        let pair = AcidKeyboardMath.blackKeyWhiteSlotIndices[idx]
+                        let midi = rootMidi + semi
+                        let xOffset =
+                            CGFloat(pair.0) * (whiteW + keyGap)
+                            + whiteW
+                            + keyGap * 0.5
+                            - max(18, whiteW * 0.58) / 2
+                        AcidKeyboardKey(
+                            midiNote: midi,
+                            label: "",
+                            isBlack: true,
+                            isPressed: pressedMidiNotes.contains(midi),
+                            whiteWidth: whiteW,
+                            whiteHeight: whiteH,
+                            gap: keyGap,
+                            onNoteOn: {
+                                onNoteOn(midi, AcidKeyboardMath.frequencyHz(midiNote: midi))
+                            },
+                            onNoteOff: { onNoteOff(midi) }
+                        )
+                        .offset(x: xOffset, y: 0)
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(height: keyboardHeight)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Teclado musical, una octava, octava \(octaveLabel)")
+    }
+
+    private var octaveLabel: String {
+        if octaveOffset == 0 { return "C4 (±0)" }
+        let sign = octaveOffset > 0 ? "+" : ""
+        return "\(sign)\(octaveOffset)"
+    }
+
+    private func whiteLabel(semitone: Int) -> String {
+        switch semitone {
+        case 0: return "C"
+        case 2: return "D"
+        case 4: return "E"
+        case 5: return "F"
+        case 7: return "G"
+        case 9: return "A"
+        case 11: return "B"
+        default: return "?"
+        }
+    }
+}
+
+#Preview("AcidKeyboard") {
+    struct Host: View {
+        @State private var oct = 0
+        @State private var down: Set<Int> = []
+        var body: some View {
+            AcidKeyboard(
+                octaveOffset: oct,
+                pressedMidiNotes: down,
+                onOctaveOffsetChange: { oct = $0 },
+                onNoteOn: { m, hz in
+                    down.insert(m)
+                    _ = hz
+                },
+                onNoteOff: { m in down.remove(m) }
+            )
+            .padding()
+        }
+    }
+    return Host()
+}

--- a/AcidMeTests/AcidKeyboardMathTests.swift
+++ b/AcidMeTests/AcidKeyboardMathTests.swift
@@ -1,0 +1,43 @@
+import Testing
+
+@testable import AcidMe
+
+@Suite("AcidKeyboardMath")
+struct AcidKeyboardMathTests {
+    @Test
+    func rootMidi_octavaC4() {
+        #expect(AcidKeyboardMath.rootMidi(octaveOffset: 0) == 60)
+    }
+
+    @Test
+    func rootMidi_limitesOctavas() {
+        #expect(AcidKeyboardMath.rootMidi(octaveOffset: -3) == 24)
+        #expect(AcidKeyboardMath.rootMidi(octaveOffset: 3) == 96)
+    }
+
+    @Test
+    func rootMidi_clampFueraDeRango() {
+        #expect(AcidKeyboardMath.rootMidi(octaveOffset: -99) == 24)
+        #expect(AcidKeyboardMath.rootMidi(octaveOffset: 99) == 96)
+    }
+
+    @Test
+    func frequencyHz_A4() {
+        let hz = AcidKeyboardMath.frequencyHz(midiNote: 69)
+        #expect(abs(hz - 440.0) < 0.001)
+    }
+
+    @Test
+    func frequencyHz_C4() {
+        let hz = AcidKeyboardMath.frequencyHz(midiNote: 60)
+        #expect(abs(hz - 261.6255653005986) < 0.01)
+    }
+
+    @Test
+    func frequencyHz_clampMidi() {
+        let low = AcidKeyboardMath.frequencyHz(midiNote: -5)
+        let high = AcidKeyboardMath.frequencyHz(midiNote: 200)
+        #expect(low == AcidKeyboardMath.frequencyHz(midiNote: 0))
+        #expect(high == AcidKeyboardMath.frequencyHz(midiNote: 127))
+    }
+}

--- a/AcidMeTests/AcidKeyboardMathTests.swift
+++ b/AcidMeTests/AcidKeyboardMathTests.swift
@@ -40,4 +40,20 @@ struct AcidKeyboardMathTests {
         #expect(low == AcidKeyboardMath.frequencyHz(midiNote: 0))
         #expect(high == AcidKeyboardMath.frequencyHz(midiNote: 127))
     }
+
+    @Test
+    func rootOctaveScientificName() {
+        #expect(AcidKeyboardMath.rootOctaveScientificName(rootMidi: 60) == "C4")
+        #expect(AcidKeyboardMath.rootOctaveScientificName(rootMidi: 48) == "C3")
+        #expect(AcidKeyboardMath.rootOctaveScientificName(rootMidi: 12) == "C0")
+    }
+
+    @Test
+    func octaveOffsetDisplay() {
+        #expect(AcidKeyboardMath.octaveOffsetDisplay(offset: 0) == "0")
+        #expect(AcidKeyboardMath.octaveOffsetDisplay(offset: 1) == "+1")
+        #expect(AcidKeyboardMath.octaveOffsetDisplay(offset: 3) == "+3")
+        #expect(AcidKeyboardMath.octaveOffsetDisplay(offset: -1) == "-1")
+        #expect(AcidKeyboardMath.octaveOffsetDisplay(offset: -3) == "-3")
+    }
 }

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -92,4 +92,41 @@ struct AppFeatureTests {
             $0.pianoRollNotes = []
         }
     }
+
+    @Test
+    func keyboardNoteOn_actualizaPulsacionYUltimaNota() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+        let hz = AcidKeyboardMath.frequencyHz(midiNote: 64)
+        await store.send(.keyboardNoteOn(midiNote: 64, frequencyHz: hz)) {
+            $0.keyboardPressedMidiNotes = [64]
+            $0.keyboardLastNoteOn = (64, hz)
+        }
+    }
+
+    @Test
+    func keyboardNoteOff_quitaPulsacion() async {
+        var state = AppFeature.State()
+        state.keyboardPressedMidiNotes = [60, 64]
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        }
+        await store.send(.keyboardNoteOff(midiNote: 64)) {
+            $0.keyboardPressedMidiNotes = [60]
+        }
+    }
+
+    @Test
+    func keyboardOctaveOffsetChanged_acota() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        }
+        await store.send(.keyboardOctaveOffsetChanged(10)) {
+            $0.keyboardOctaveOffset = 3
+        }
+        await store.send(.keyboardOctaveOffsetChanged(-10)) {
+            $0.keyboardOctaveOffset = -3
+        }
+    }
 }

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -129,4 +129,33 @@ struct AppFeatureTests {
             $0.keyboardOctaveOffset = -3
         }
     }
+
+    @Test
+    func keyboardOctaveOffsetChanged_valoresIntermedios() async {
+        let store = TestStore(initialState: AppFeature.State(keyboardOctaveOffset: 0)) {
+            AppFeature()
+        }
+        await store.send(.keyboardOctaveOffsetChanged(2)) {
+            $0.keyboardOctaveOffset = 2
+        }
+        await store.send(.keyboardOctaveOffsetChanged(-1)) {
+            $0.keyboardOctaveOffset = -1
+        }
+    }
+
+    @Test
+    func stateEquality_incluyeTecladoYUltimaNota() {
+        var a = AppFeature.State()
+        var b = AppFeature.State()
+        let hz = AcidKeyboardMath.frequencyHz(midiNote: 60)
+        a.keyboardOctaveOffset = 1
+        a.keyboardPressedMidiNotes = [60]
+        a.keyboardLastNoteOn = (60, hz)
+        b.keyboardOctaveOffset = 1
+        b.keyboardPressedMidiNotes = [60]
+        b.keyboardLastNoteOn = (60, hz)
+        #expect(a == b)
+        b.keyboardLastNoteOn = (61, hz)
+        #expect(a != b)
+    }
 }


### PR DESCRIPTION
## Resumen
Implementa el selector de octava del teclado musical (HU 5) con estilo coherente con AcidButton, etiqueta numérica de desplazamiento (0, +n, −n) y cobertura de tests.

## Cambios principales
- **AcidKeyboard**: fila de octava con botones −/+, estilo metal compacto, centro con `AcidKeyboardMath.octaveOffsetDisplay`.
- **AcidKeyboardMath**: función `octaveOffsetDisplay(offset:)` testeada en `AcidKeyboardMathTests`.
- **AppFeature**: comparación manual de `State` que incluye teclado y última nota; tests de reducer e igualdad en `AppFeatureTests`.
- **AcidButton**: padding configurable para controles más compactos.
- Eliminado `Features/.gitkeep` (la carpeta ya tiene contenido).

## Cómo probar
- Ejecutar tests: `xcodebuild -scheme AcidMe -destination 'platform=iOS Simulator,name=iPhone 16' test`
- En simulador: verificar teclado, cambio de octava y accesibilidad.

Made with [Cursor](https://cursor.com)