### PR TITLE
feat(HU6): AudioClient TCA + arranque del motor AudioKit

### DIFF
--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -25,6 +25,7 @@
 		E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */; };
 		E73AA2F81B89757051283D57 /* AcidKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917F0F3E18EC986870855A06 /* AcidKeyboard.swift */; };
 		FDFBC7AC139584F4B17B6589 /* Perception in Frameworks */ = {isa = PBXBuildFile; productRef = 2D0348C6BA11532A7A728F65 /* Perception */; };
+		FECE2264436AC76CDD84996B /* AudioClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12C86689A5947FEE0B0F2F38 /* AudioClient.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +40,7 @@
 
 /* Begin PBXFileReference section */
 		0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggleSelectionTests.swift; sourceTree = "<group>"; };
+		12C86689A5947FEE0B0F2F38 /* AudioClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioClient.swift; sourceTree = "<group>"; };
 		1429EFE4D1429D0BC5C55E16 /* AcidKnobMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnobMathTests.swift; sourceTree = "<group>"; };
 		1976140D3190C10989DF090E /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButtonTests.swift; sourceTree = "<group>"; };
@@ -115,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */,
+				12C86689A5947FEE0B0F2F38 /* AudioClient.swift */,
 				C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */,
 			);
 			path = Core;
@@ -251,6 +254,7 @@
 				C8AD1F78E343A5FD3FDB6E49 /* AcidPianoRoll.swift in Sources */,
 				05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */,
 				8F90CFBED1385137F71B1CE6 /* AppFeature.swift in Sources */,
+				FECE2264436AC76CDD84996B /* AudioClient.swift in Sources */,
 				04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */,
 				882409673B5C11AF4F05E788 /* ContentView.swift in Sources */,
 			);

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -11,7 +11,7 @@ struct AppView: View {
             VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 4–5 · Piano roll + AcidKeyboard (Note On + Hz) + controles anteriores")
+                Text("HU 4–6 · Piano roll + teclado + AudioClient (motor AudioKit)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -81,14 +81,25 @@ struct AppView: View {
                         .frame(minWidth: 120, alignment: .leading)
                 }
 
-                if AudioKitBootstrap.isModuleLinked {
-                    Text("AudioKit enlazado")
+                if let err = store.audioEnginePrepareError {
+                    Text("Audio: \(err)")
+                        .font(.caption2)
+                        .foregroundStyle(.red)
+                } else if store.audioEnginePrepared {
+                    Text("Motor de audio listo")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                } else if AudioKitBootstrap.isModuleLinked {
+                    Text("Iniciando motor de audio…")
                         .font(.caption2)
                         .foregroundStyle(.tertiary)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(Color(red: 0.95, green: 0.85, blue: 0.15).opacity(0.15))
+            .task {
+                await store.send(.prepareAudioEngine).finish()
+            }
         }
     }
 }

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -17,6 +17,8 @@ struct AppFeature {
             && lhs.keyboardPressedMidiNotes == rhs.keyboardPressedMidiNotes
             && lhs.keyboardLastNoteOn?.midiNote == rhs.keyboardLastNoteOn?.midiNote
             && lhs.keyboardLastNoteOn?.frequencyHz == rhs.keyboardLastNoteOn?.frequencyHz
+            && lhs.audioEnginePrepared == rhs.audioEnginePrepared
+            && lhs.audioEnginePrepareError == rhs.audioEnginePrepareError
         }
 
         /// Valor de demostración del AcidKnob (HU 1); más adelante se sustituirá por parámetros reales de síntesis.
@@ -34,6 +36,9 @@ struct AppFeature {
         var keyboardPressedMidiNotes: Set<Int> = []
         /// Último Note On (demo hasta AudioClient en HU 6).
         var keyboardLastNoteOn: (midiNote: Int, frequencyHz: Double)?
+        /// HU 6: motor AudioKit listo para recibir comandos.
+        var audioEnginePrepared: Bool = false
+        var audioEnginePrepareError: String?
     }
 
     enum Action: BindableAction, Equatable {
@@ -48,6 +53,10 @@ struct AppFeature {
         case keyboardOctaveOffsetChanged(Int)
         case keyboardNoteOn(midiNote: Int, frequencyHz: Double)
         case keyboardNoteOff(midiNote: Int)
+        /// Arranca el motor de audio una vez al iniciar la UI raíz.
+        case prepareAudioEngine
+        case audioEnginePrepared
+        case audioEnginePrepareFailed(String)
     }
 
     var body: some ReducerOf<Self> {
@@ -118,6 +127,24 @@ struct AppFeature {
                 return .none
             case let .keyboardNoteOff(midiNote):
                 state.keyboardPressedMidiNotes.remove(midiNote)
+                return .none
+            case .prepareAudioEngine:
+                return .run { send in
+                    @Dependency(\.audioClient) var audioClient
+                    do {
+                        try await audioClient.prepare()
+                        await send(.audioEnginePrepared)
+                    } catch {
+                        await send(.audioEnginePrepareFailed(error.localizedDescription))
+                    }
+                }
+            case .audioEnginePrepared:
+                state.audioEnginePrepared = true
+                state.audioEnginePrepareError = nil
+                return .none
+            case let .audioEnginePrepareFailed(message):
+                state.audioEnginePrepared = false
+                state.audioEnginePrepareError = message
                 return .none
             }
         }

--- a/AcidMe/Core/AudioClient.swift
+++ b/AcidMe/Core/AudioClient.swift
@@ -1,0 +1,53 @@
+import AudioKit
+import AVFoundation
+import ComposableArchitecture
+import Foundation
+
+// MARK: - Motor en vivo (AudioKit)
+
+@MainActor
+final class LiveAudioKitEngine {
+    static let shared = LiveAudioKitEngine()
+
+    private var engine: AudioEngine?
+
+    private init() {}
+
+    /// Configura la sesión de audio, crea un grafo mínimo (oscilador en silencio) y arranca el motor.
+    func prepare() throws {
+        guard engine == nil else { return }
+
+        let session = AVAudioSession.sharedInstance()
+        try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
+        try session.setActive(true)
+
+        let oscillator = PlaygroundOscillator(waveform: Table(.sine), frequency: 440, amplitude: 0)
+        let eng = AudioEngine()
+        eng.output = oscillator
+        try eng.start()
+        engine = eng
+    }
+}
+
+// MARK: - Dependencia TCA
+
+struct AudioClient: Sendable {
+    var prepare: @Sendable () async throws -> Void
+}
+
+extension AudioClient: DependencyKey {
+    static let liveValue = AudioClient(
+        prepare: {
+            try await LiveAudioKitEngine.shared.prepare()
+        }
+    )
+
+    static let testValue = AudioClient(prepare: {})
+}
+
+extension DependencyValues {
+    var audioClient: AudioClient {
+        get { self[AudioClient.self] }
+        set { self[AudioClient.self] = newValue }
+    }
+}

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -144,6 +144,40 @@ struct AppFeatureTests {
     }
 
     @Test
+    func prepareAudioEngine_invocaClienteYMarcaListo() async {
+        var prepareCalls = 0
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient.prepare = {
+                prepareCalls += 1
+            }
+        }
+        await store.send(.prepareAudioEngine)
+        await store.receive(.audioEnginePrepared) {
+            $0.audioEnginePrepared = true
+            $0.audioEnginePrepareError = nil
+        }
+        #expect(prepareCalls == 1)
+    }
+
+    @Test
+    func prepareAudioEngine_errorActualizaEstado() async {
+        let store = TestStore(initialState: AppFeature.State()) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient.prepare = {
+                throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "fallo simulado"])
+            }
+        }
+        await store.send(.prepareAudioEngine)
+        await store.receive(.audioEnginePrepareFailed("fallo simulado")) {
+            $0.audioEnginePrepared = false
+            $0.audioEnginePrepareError = "fallo simulado"
+        }
+    }
+
+    @Test
     func stateEquality_incluyeTecladoYUltimaNota() {
         var a = AppFeature.State()
         var b = AppFeature.State()


### PR DESCRIPTION
## Resumen
Integración inicial del **AudioClient** (TCA + AudioKit) según HU 6: al cargar la UI raíz se prepara el motor de audio y el estado refleja éxito o error.

## Cambios
- Dependencia `AudioClient` con implementación en vivo (`LiveAudioKitEngine`): sesión `.playback`, grafo mínimo con `PlaygroundOscillator` en silencio, `AudioEngine.start()`.
- `AppFeature`: acciones `prepareAudioEngine`, `audioEnginePrepared`, `audioEnginePrepareFailed`; estado `audioEnginePrepared` / `audioEnginePrepareError`.
- `ContentView`: `.task` que envía `prepareAudioEngine` y textos de estado del motor.
- Tests del reducer con cliente inyectado.

## Pruebas
`xcodebuild -scheme AcidMe -destination 'platform=iOS Simulator,name=iPhone 16' test`

Made with [Cursor](https://cursor.com)