### PR TITLE
feat(HU7): parámetros síntesis + fix cutoff LPF

### DIFF
--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */; };
 		05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72527E242323BE0F165CB92F /* AcidToggle.swift */; };
+		06CD690D4CC336BA97CE38B6 /* SynthParamsMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDD18095DCE4EDB7A198883 /* SynthParamsMathTests.swift */; };
 		2AEDF4A5F7DDC8BD1B9746AE /* AcidButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */; };
 		505D4E417396FFF108119186 /* PianoRollGridMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4B7A640174A43915414678 /* PianoRollGridMathTests.swift */; };
 		6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */; };
@@ -22,6 +23,7 @@
 		9F47412D5D333BE53A511FD5 /* AcidKeyboardMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E666C9AB4E64FDCD9675B910 /* AcidKeyboardMathTests.swift */; };
 		C8AD1F78E343A5FD3FDB6E49 /* AcidPianoRoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E8C27A722E097E29D34EF8 /* AcidPianoRoll.swift */; };
 		CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973DB5D629F27409804B1093 /* AcidMeApp.swift */; };
+		D8FEEF9F312E51F14D518A01 /* SynthParamsMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FEE44C7EDF48761ADDCF20 /* SynthParamsMath.swift */; };
 		E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */; };
 		E73AA2F81B89757051283D57 /* AcidKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917F0F3E18EC986870855A06 /* AcidKeyboard.swift */; };
 		FDFBC7AC139584F4B17B6589 /* Perception in Frameworks */ = {isa = PBXBuildFile; productRef = 2D0348C6BA11532A7A728F65 /* Perception */; };
@@ -47,6 +49,7 @@
 		1F4B7A640174A43915414678 /* PianoRollGridMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PianoRollGridMathTests.swift; sourceTree = "<group>"; };
 		3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButton.swift; sourceTree = "<group>"; };
 		72527E242323BE0F165CB92F /* AcidToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggle.swift; sourceTree = "<group>"; };
+		72FEE44C7EDF48761ADDCF20 /* SynthParamsMath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynthParamsMath.swift; sourceTree = "<group>"; };
 		85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnob.swift; sourceTree = "<group>"; };
 		917F0F3E18EC986870855A06 /* AcidKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKeyboard.swift; sourceTree = "<group>"; };
 		973DB5D629F27409804B1093 /* AcidMeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidMeApp.swift; sourceTree = "<group>"; };
@@ -55,6 +58,7 @@
 		CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeature.swift; sourceTree = "<group>"; };
 		D12FA876D6E8CEE040984562 /* AcidMeTests.xctest */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.cfbundle; path = AcidMeTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3B5A66BD50A60974610B2A2 /* AcidMe.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = AcidMe.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		DBDD18095DCE4EDB7A198883 /* SynthParamsMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynthParamsMathTests.swift; sourceTree = "<group>"; };
 		E2E8C27A722E097E29D34EF8 /* AcidPianoRoll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidPianoRoll.swift; sourceTree = "<group>"; };
 		E666C9AB4E64FDCD9675B910 /* AcidKeyboardMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKeyboardMathTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -90,6 +94,7 @@
 				0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */,
 				A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */,
 				1F4B7A640174A43915414678 /* PianoRollGridMathTests.swift */,
+				DBDD18095DCE4EDB7A198883 /* SynthParamsMathTests.swift */,
 			);
 			path = AcidMeTests;
 			sourceTree = "<group>";
@@ -119,6 +124,7 @@
 				CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */,
 				12C86689A5947FEE0B0F2F38 /* AudioClient.swift */,
 				C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */,
+				72FEE44C7EDF48761ADDCF20 /* SynthParamsMath.swift */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -240,6 +246,7 @@
 				97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */,
 				6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */,
 				505D4E417396FFF108119186 /* PianoRollGridMathTests.swift in Sources */,
+				06CD690D4CC336BA97CE38B6 /* SynthParamsMathTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -257,6 +264,7 @@
 				FECE2264436AC76CDD84996B /* AudioClient.swift in Sources */,
 				04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */,
 				882409673B5C11AF4F05E788 /* ContentView.swift in Sources */,
+				D8FEEF9F312E51F14D518A01 /* SynthParamsMath.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -11,7 +11,7 @@ struct AppView: View {
             VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 4–6 · Piano roll + teclado + AudioClient (motor AudioKit)")
+                Text("HU 4–7 · Piano roll + teclado + motor + parámetros demo (cutoff / onda)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -62,7 +62,7 @@ struct AppView: View {
                     VStack(spacing: 8) {
                         AcidKnob(
                             value: $store.demoKnobValue,
-                            label: "DEMO"
+                            label: "CUTOFF"
                         )
                         Text(String(format: "valor: %.3f", store.demoKnobValue))
                             .font(.caption.monospacedDigit())

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -66,7 +66,12 @@ struct AppFeature {
             case .binding:
                 // Tras cualquier binding, mantiene el knob en 0…1 (p. ej. arrastre del AcidKnob).
                 state.demoKnobValue = min(1, max(0, state.demoKnobValue))
-                return .none
+                let k = state.demoKnobValue
+                let t = state.demoToggleSelection
+                return .run { _ in
+                    @Dependency(\.audioClient) var audioClient
+                    await audioClient.applyDemoSynthParams(k, t)
+                }
             case .demoPlayButtonReleased:
                 state.demoPlayButtonReleaseCount += 1
                 return .none
@@ -74,7 +79,12 @@ struct AppFeature {
                 state.demoClearButtonReleaseCount += 1
                 state.demoKnobValue = 0
                 state.pianoRollNotes = []
-                return .none
+                let k = state.demoKnobValue
+                let t = state.demoToggleSelection
+                return .run { _ in
+                    @Dependency(\.audioClient) var audioClient
+                    await audioClient.applyDemoSynthParams(k, t)
+                }
             case let .pianoRollGridStepsChanged(raw):
                 let steps = PianoRollGridMath.normalizedGridSteps(raw)
                 state.pianoRollGridSteps = steps
@@ -141,7 +151,12 @@ struct AppFeature {
             case .audioEnginePrepared:
                 state.audioEnginePrepared = true
                 state.audioEnginePrepareError = nil
-                return .none
+                let k = state.demoKnobValue
+                let t = state.demoToggleSelection
+                return .run { _ in
+                    @Dependency(\.audioClient) var audioClient
+                    await audioClient.applyDemoSynthParams(k, t)
+                }
             case let .audioEnginePrepareFailed(message):
                 state.audioEnginePrepared = false
                 state.audioEnginePrepareError = message

--- a/AcidMe/Core/AudioClient.swift
+++ b/AcidMe/Core/AudioClient.swift
@@ -41,29 +41,30 @@ final class LiveAudioKitEngine {
         lowPass = filter
     }
 
-    /// Aplica cutoff (knob 0…1) y selección de onda; ramps cortos para evitar clics.
+    /// Aplica cutoff (knob 0…1) y selección de onda.
+    /// El cutoff del `LowPassFilter` (Audio Unit de Apple) suele **no** admitir `NodeParameter.ramp`;
+    /// si se llama a `ramp`, no actualiza el valor. Asignación directa al `@Parameter` sí.
+    /// `PlaygroundOscillator.amplitude` no es `@Parameter`: solo asignación directa.
     func applyDemoSynthParams(knobNormalized: Double, toggle: AcidToggleSelection) {
         guard let lowPass, let sawOsc, let sqrOsc else { return }
 
-        let hz = SynthParamsMath.lowPassCutoffHz(normalized01: knobNormalized)
-        let d = DemoSynth.rampSeconds
-        lowPass.$cutoffFrequency.ramp(to: hz, duration: d)
+        let hz = AUValue(SynthParamsMath.lowPassCutoffHz(normalized01: knobNormalized))
+        lowPass.cutoffFrequency = hz
 
         let level = DemoSynth.oscLevel
         switch toggle {
         case .upper:
-            sawOsc.$amplitude.ramp(to: level, duration: d)
-            sqrOsc.$amplitude.ramp(to: 0, duration: d)
+            sawOsc.amplitude = level
+            sqrOsc.amplitude = 0
         case .lower:
-            sawOsc.$amplitude.ramp(to: 0, duration: d)
-            sqrOsc.$amplitude.ramp(to: level, duration: d)
+            sawOsc.amplitude = 0
+            sqrOsc.amplitude = level
         }
     }
 }
 
 private enum DemoSynth {
     static let oscLevel: AUValue = 0.03
-    static let rampSeconds: Float = 0.03
 }
 
 // MARK: - Dependencia TCA

--- a/AcidMe/Core/AudioClient.swift
+++ b/AcidMe/Core/AudioClient.swift
@@ -10,10 +10,13 @@ final class LiveAudioKitEngine {
     static let shared = LiveAudioKitEngine()
 
     private var engine: AudioEngine?
+    private var sawOsc: PlaygroundOscillator?
+    private var sqrOsc: PlaygroundOscillator?
+    private var lowPass: LowPassFilter?
 
     private init() {}
 
-    /// Configura la sesión de audio, crea un grafo mínimo (oscilador en silencio) y arranca el motor.
+    /// Configura la sesión, monta dos osciladores (sierra/cuadrado) → mezcla → LPF y arranca el motor.
     func prepare() throws {
         guard engine == nil else { return }
 
@@ -21,28 +24,69 @@ final class LiveAudioKitEngine {
         try session.setCategory(.playback, mode: .default, options: [.mixWithOthers])
         try session.setActive(true)
 
-        let oscillator = PlaygroundOscillator(waveform: Table(.sine), frequency: 440, amplitude: 0)
+        let saw = PlaygroundOscillator(waveform: Table(.sawtooth), frequency: 110, amplitude: 0)
+        let sqr = PlaygroundOscillator(waveform: Table(.square), frequency: 110, amplitude: 0)
+        saw.start()
+        sqr.start()
+
+        let mixer = Mixer(saw, sqr)
+        let filter = LowPassFilter(mixer, cutoffFrequency: 6_900, resonance: 2)
         let eng = AudioEngine()
-        eng.output = oscillator
+        eng.output = filter
         try eng.start()
+
         engine = eng
+        sawOsc = saw
+        sqrOsc = sqr
+        lowPass = filter
     }
+
+    /// Aplica cutoff (knob 0…1) y selección de onda; ramps cortos para evitar clics.
+    func applyDemoSynthParams(knobNormalized: Double, toggle: AcidToggleSelection) {
+        guard let lowPass, let sawOsc, let sqrOsc else { return }
+
+        let hz = SynthParamsMath.lowPassCutoffHz(normalized01: knobNormalized)
+        let d = DemoSynth.rampSeconds
+        lowPass.$cutoffFrequency.ramp(to: hz, duration: d)
+
+        let level = DemoSynth.oscLevel
+        switch toggle {
+        case .upper:
+            sawOsc.$amplitude.ramp(to: level, duration: d)
+            sqrOsc.$amplitude.ramp(to: 0, duration: d)
+        case .lower:
+            sawOsc.$amplitude.ramp(to: 0, duration: d)
+            sqrOsc.$amplitude.ramp(to: level, duration: d)
+        }
+    }
+}
+
+private enum DemoSynth {
+    static let oscLevel: AUValue = 0.03
+    static let rampSeconds: Float = 0.03
 }
 
 // MARK: - Dependencia TCA
 
 struct AudioClient: Sendable {
     var prepare: @Sendable () async throws -> Void
+    var applyDemoSynthParams: @Sendable (Double, AcidToggleSelection) async -> Void
 }
 
 extension AudioClient: DependencyKey {
     static let liveValue = AudioClient(
         prepare: {
             try await LiveAudioKitEngine.shared.prepare()
+        },
+        applyDemoSynthParams: { knob, toggle in
+            await LiveAudioKitEngine.shared.applyDemoSynthParams(knobNormalized: knob, toggle: toggle)
         }
     )
 
-    static let testValue = AudioClient(prepare: {})
+    static let testValue = AudioClient(
+        prepare: {},
+        applyDemoSynthParams: { _, _ in }
+    )
 }
 
 extension DependencyValues {

--- a/AcidMe/Core/SynthParamsMath.swift
+++ b/AcidMe/Core/SynthParamsMath.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Mapeos de parámetros de síntesis (HU 7) desacoplados de AudioKit.
+enum SynthParamsMath {
+    /// Mapea 0…1 a frecuencia de corte (Hz) con progresión logarítmica.
+    static func lowPassCutoffHz(normalized01: Double) -> Float {
+        let n = min(1, max(0, normalized01))
+        let minHz: Float = 150
+        let maxHz: Float = 14_000
+        return minHz * pow(maxHz / minHz, Float(n))
+    }
+}

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -120,14 +120,23 @@ struct AppFeatureTests {
         state.pianoRollNotes = [
             PianoRollNote(id: UUID(), row: 1, startStep: 2, lengthSteps: 1)
         ]
+        var applyCount = 0
         let store = TestStore(initialState: state) {
             AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { _, _ in
+                    applyCount += 1
+                }
+            )
         }
         await store.send(.demoClearButtonReleased) {
             $0.demoClearButtonReleaseCount = 1
             $0.demoKnobValue = 0
             $0.pianoRollNotes = []
         }
+        #expect(applyCount == 1)
     }
 
     @Test
@@ -183,12 +192,15 @@ struct AppFeatureTests {
     @Test
     func prepareAudioEngine_invocaClienteYMarcaListo() async {
         var prepareCalls = 0
+        var applyCalls = 0
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
             $0.audioClient = AudioClient(
                 prepare: { prepareCalls += 1 },
-                applyDemoSynthParams: { _, _ in }
+                applyDemoSynthParams: { _, _ in
+                    applyCalls += 1
+                }
             )
         }
         await store.send(.prepareAudioEngine)
@@ -197,6 +209,33 @@ struct AppFeatureTests {
             $0.audioEnginePrepareError = nil
         }
         #expect(prepareCalls == 1)
+        #expect(applyCalls == 1)
+    }
+
+    @Test
+    func prepareAudioEngine_sincronizaKnobYToggleTrasEstarListo() async {
+        var lastKnob: Double?
+        var lastToggle: AcidToggleSelection?
+        let store = TestStore(
+            initialState: AppFeature.State(demoKnobValue: 0.42, demoToggleSelection: .lower)
+        ) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { k, t in
+                    lastKnob = k
+                    lastToggle = t
+                }
+            )
+        }
+        await store.send(.prepareAudioEngine)
+        await store.receive(.audioEnginePrepared) {
+            $0.audioEnginePrepared = true
+            $0.audioEnginePrepareError = nil
+        }
+        #expect(lastKnob == 0.42)
+        #expect(lastToggle == .lower)
     }
 
     @Test
@@ -216,6 +255,17 @@ struct AppFeatureTests {
             $0.audioEnginePrepared = false
             $0.audioEnginePrepareError = "fallo simulado"
         }
+    }
+
+    @Test
+    func stateEquality_incluyeFlagsDelMotorDeAudio() {
+        var a = AppFeature.State()
+        var b = AppFeature.State()
+        a.audioEnginePrepared = true
+        b.audioEnginePrepared = true
+        #expect(a == b)
+        b.audioEnginePrepareError = "x"
+        #expect(a != b)
     }
 
     @Test

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -29,6 +29,34 @@ struct AppFeatureTests {
     }
 
     @Test
+    func binding_propagaParametrosAlAudioClient() async {
+        var lastKnob: Double?
+        var lastToggle: AcidToggleSelection?
+        let store = TestStore(initialState: AppFeature.State(demoKnobValue: 0.2, demoToggleSelection: .upper)) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { k, t in
+                    lastKnob = k
+                    lastToggle = t
+                }
+            )
+        }
+        await store.send(.binding(.set(\.demoKnobValue, 0.7))) {
+            $0.demoKnobValue = 0.7
+        }
+        #expect(lastKnob == 0.7)
+        #expect(lastToggle == .upper)
+
+        await store.send(.binding(.set(\.demoToggleSelection, .lower))) {
+            $0.demoToggleSelection = .lower
+        }
+        #expect(lastKnob == 0.7)
+        #expect(lastToggle == .lower)
+    }
+
+    @Test
     func binding_demoToggleSelection_actualizaEstado() async {
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
@@ -53,14 +81,23 @@ struct AppFeatureTests {
 
     @Test
     func demoClearButtonReleased_incrementaYReseteaKnob() async {
+        var lastKnob: Double?
         let store = TestStore(initialState: AppFeature.State(demoKnobValue: 0.8)) {
             AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { k, _ in
+                    lastKnob = k
+                }
+            )
         }
         await store.send(.demoClearButtonReleased) {
             $0.demoClearButtonReleaseCount = 1
             $0.demoKnobValue = 0
             $0.pianoRollNotes = []
         }
+        #expect(lastKnob == 0)
     }
 
     @Test
@@ -149,9 +186,10 @@ struct AppFeatureTests {
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
-            $0.audioClient.prepare = {
-                prepareCalls += 1
-            }
+            $0.audioClient = AudioClient(
+                prepare: { prepareCalls += 1 },
+                applyDemoSynthParams: { _, _ in }
+            )
         }
         await store.send(.prepareAudioEngine)
         await store.receive(.audioEnginePrepared) {
@@ -166,9 +204,12 @@ struct AppFeatureTests {
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
         } withDependencies: {
-            $0.audioClient.prepare = {
-                throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "fallo simulado"])
-            }
+            $0.audioClient = AudioClient(
+                prepare: {
+                    throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "fallo simulado"])
+                },
+                applyDemoSynthParams: { _, _ in }
+            )
         }
         await store.send(.prepareAudioEngine)
         await store.receive(.audioEnginePrepareFailed("fallo simulado")) {

--- a/AcidMeTests/SynthParamsMathTests.swift
+++ b/AcidMeTests/SynthParamsMathTests.swift
@@ -1,0 +1,24 @@
+import Foundation
+import Testing
+
+@testable import AcidMe
+
+@Suite
+struct SynthParamsMathTests {
+    @Test
+    func lowPassCutoffHz_extremos() {
+        let lo = SynthParamsMath.lowPassCutoffHz(normalized01: 0)
+        let hi = SynthParamsMath.lowPassCutoffHz(normalized01: 1)
+        #expect(lo < hi)
+        #expect(lo >= 150)
+        #expect(hi <= 14_000)
+    }
+
+    @Test
+    func lowPassCutoffHz_acotaFueraDeRango() {
+        let a = SynthParamsMath.lowPassCutoffHz(normalized01: -1)
+        let b = SynthParamsMath.lowPassCutoffHz(normalized01: 2)
+        #expect(a == SynthParamsMath.lowPassCutoffHz(normalized01: 0))
+        #expect(b == SynthParamsMath.lowPassCutoffHz(normalized01: 1))
+    }
+}

--- a/AcidMeTests/SynthParamsMathTests.swift
+++ b/AcidMeTests/SynthParamsMathTests.swift
@@ -21,4 +21,21 @@ struct SynthParamsMathTests {
         #expect(a == SynthParamsMath.lowPassCutoffHz(normalized01: 0))
         #expect(b == SynthParamsMath.lowPassCutoffHz(normalized01: 1))
     }
+
+    @Test
+    func lowPassCutoffHz_extremosNumericosExactos() {
+        #expect(SynthParamsMath.lowPassCutoffHz(normalized01: 0) == 150)
+        #expect(SynthParamsMath.lowPassCutoffHz(normalized01: 1) == 14_000)
+    }
+
+    @Test
+    func lowPassCutoffHz_esCrecienteEn01() {
+        let steps = stride(from: 0.0, through: 1.0, by: 0.1).map { Double($0) }
+        var previous = SynthParamsMath.lowPassCutoffHz(normalized01: steps[0])
+        for n in steps.dropFirst() {
+            let next = SynthParamsMath.lowPassCutoffHz(normalized01: n)
+            #expect(next >= previous)
+            previous = next
+        }
+    }
 }


### PR DESCRIPTION
## Resumen
Conecta el knob **CUTOFF** y el toggle **SAW/SQR** al grafo AudioKit (sierra/cuadrado → mixer → LPF) y corrige el cutoff para que el AU lo actualice de verdad.

## Cambios clave
- **Audio**: dos `PlaygroundOscillator`, `Mixer`, `LowPassFilter`; amplitudes por onda; **cutoff** con asignación directa (`cutoffFrequency = hz`) porque `ramp` del LPF de Apple no aplicaba.
- **TCA**: `applyDemoSynthParams` tras bindings, tras motor listo y tras CLEAR.
- **SynthParamsMath**: mapeo log 0…1 → Hz + tests.
- **Tests**: sync tras `prepare`, knob/toggle iniciales, igualdad de estado del motor, CLEAR con cliente inyectado.

## Cómo probar
`xcodebuild -scheme AcidMe -destination 'platform=iOS Simulator,name=iPhone 16' test`

Made with [Cursor](https://cursor.com)