### PR TITLE
feat(HU8): secuenciador y transporte PLAY/STOP

### DIFF
--- a/AcidMe.xcodeproj/project.pbxproj
+++ b/AcidMe.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		05B28052F24782E2405EA953 /* AcidToggle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72527E242323BE0F165CB92F /* AcidToggle.swift */; };
 		06CD690D4CC336BA97CE38B6 /* SynthParamsMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBDD18095DCE4EDB7A198883 /* SynthParamsMathTests.swift */; };
 		2AEDF4A5F7DDC8BD1B9746AE /* AcidButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */; };
+		32EDE2CFF5A56409CE93C344 /* PianoRollSequencerMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 650A126B92D38FDD347AA02B /* PianoRollSequencerMathTests.swift */; };
 		505D4E417396FFF108119186 /* PianoRollGridMathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4B7A640174A43915414678 /* PianoRollGridMathTests.swift */; };
 		6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */; };
 		86E3B0D5A89CC26FCF922CCB /* AudioKit in Frameworks */ = {isa = PBXBuildFile; productRef = FE0F508000A1F0425A520A5C /* AudioKit */; };
@@ -24,6 +25,7 @@
 		C8AD1F78E343A5FD3FDB6E49 /* AcidPianoRoll.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2E8C27A722E097E29D34EF8 /* AcidPianoRoll.swift */; };
 		CE304586C2F300256A022A53 /* AcidMeApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 973DB5D629F27409804B1093 /* AcidMeApp.swift */; };
 		D8FEEF9F312E51F14D518A01 /* SynthParamsMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 72FEE44C7EDF48761ADDCF20 /* SynthParamsMath.swift */; };
+		E03ADCA2249C629AD4199221 /* PianoRollSequencerMath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D69B690C390F8DBA4E79518 /* PianoRollSequencerMath.swift */; };
 		E0A9144D29558897D8FD1ED3 /* AcidKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */; };
 		E73AA2F81B89757051283D57 /* AcidKeyboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917F0F3E18EC986870855A06 /* AcidKeyboard.swift */; };
 		FDFBC7AC139584F4B17B6589 /* Perception in Frameworks */ = {isa = PBXBuildFile; productRef = 2D0348C6BA11532A7A728F65 /* Perception */; };
@@ -48,9 +50,11 @@
 		1C74C92758A1EC6F49F23E30 /* AcidButtonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButtonTests.swift; sourceTree = "<group>"; };
 		1F4B7A640174A43915414678 /* PianoRollGridMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PianoRollGridMathTests.swift; sourceTree = "<group>"; };
 		3D9B647A79ED1E0E065B36D8 /* AcidButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidButton.swift; sourceTree = "<group>"; };
+		650A126B92D38FDD347AA02B /* PianoRollSequencerMathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PianoRollSequencerMathTests.swift; sourceTree = "<group>"; };
 		72527E242323BE0F165CB92F /* AcidToggle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidToggle.swift; sourceTree = "<group>"; };
 		72FEE44C7EDF48761ADDCF20 /* SynthParamsMath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SynthParamsMath.swift; sourceTree = "<group>"; };
 		85B9A2C6CFF54E9A2CB8F598 /* AcidKnob.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKnob.swift; sourceTree = "<group>"; };
+		8D69B690C390F8DBA4E79518 /* PianoRollSequencerMath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PianoRollSequencerMath.swift; sourceTree = "<group>"; };
 		917F0F3E18EC986870855A06 /* AcidKeyboard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidKeyboard.swift; sourceTree = "<group>"; };
 		973DB5D629F27409804B1093 /* AcidMeApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AcidMeApp.swift; sourceTree = "<group>"; };
 		A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppFeatureTests.swift; sourceTree = "<group>"; };
@@ -94,6 +98,7 @@
 				0083D446F27199C7C8DCF084 /* AcidToggleSelectionTests.swift */,
 				A66D02A9BB902AC25D048B2B /* AppFeatureTests.swift */,
 				1F4B7A640174A43915414678 /* PianoRollGridMathTests.swift */,
+				650A126B92D38FDD347AA02B /* PianoRollSequencerMathTests.swift */,
 				DBDD18095DCE4EDB7A198883 /* SynthParamsMathTests.swift */,
 			);
 			path = AcidMeTests;
@@ -124,6 +129,7 @@
 				CF5D7BCC1FB8CA11F0B341A2 /* AppFeature.swift */,
 				12C86689A5947FEE0B0F2F38 /* AudioClient.swift */,
 				C9A3B10ADF925E36015EA4FB /* AudioKitBootstrap.swift */,
+				8D69B690C390F8DBA4E79518 /* PianoRollSequencerMath.swift */,
 				72FEE44C7EDF48761ADDCF20 /* SynthParamsMath.swift */,
 			);
 			path = Core;
@@ -246,6 +252,7 @@
 				97B807EE9805154AC7842C7A /* AcidToggleSelectionTests.swift in Sources */,
 				6438068100CAD48800BA1FF4 /* AppFeatureTests.swift in Sources */,
 				505D4E417396FFF108119186 /* PianoRollGridMathTests.swift in Sources */,
+				32EDE2CFF5A56409CE93C344 /* PianoRollSequencerMathTests.swift in Sources */,
 				06CD690D4CC336BA97CE38B6 /* SynthParamsMathTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -264,6 +271,7 @@
 				FECE2264436AC76CDD84996B /* AudioClient.swift in Sources */,
 				04A12C56C87872B89D7B68EC /* AudioKitBootstrap.swift in Sources */,
 				882409673B5C11AF4F05E788 /* ContentView.swift in Sources */,
+				E03ADCA2249C629AD4199221 /* PianoRollSequencerMath.swift in Sources */,
 				D8FEEF9F312E51F14D518A01 /* SynthParamsMath.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/AcidMe/App/ContentView.swift
+++ b/AcidMe/App/ContentView.swift
@@ -11,7 +11,7 @@ struct AppView: View {
             VStack(spacing: 24) {
                 Text("AcidMe!")
                     .font(.largeTitle.bold())
-                Text("HU 4–7 · Piano roll + teclado + motor + parámetros demo (cutoff / onda)")
+                Text("HU 4–8 · Roll + secuenciador + teclado + motor + cutoff / onda")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -19,6 +19,7 @@ struct AppView: View {
                 AcidPianoRoll(
                     gridSteps: store.pianoRollGridSteps,
                     notes: store.pianoRollNotes,
+                    playheadStep: store.sequencerIsRunning ? store.sequencerPlayheadStep : nil,
                     onGridStepsChange: { store.send(.pianoRollGridStepsChanged($0)) },
                     onStepTap: { row, step in store.send(.pianoRollStepToggled(row: row, step: step)) },
                     onStepsPainted: { row, a, b in
@@ -50,12 +51,18 @@ struct AppView: View {
                     AcidButton(title: "PLAY", systemImage: "play.fill") {
                         store.send(.demoPlayButtonReleased)
                     }
+                    AcidButton(title: "STOP", systemImage: "stop.fill") {
+                        store.send(.sequencerStopTapped)
+                    }
                     AcidButton(title: "CLEAR", systemImage: "trash") {
                         store.send(.demoClearButtonReleased)
                     }
-                    Text("PLAY \(store.demoPlayButtonReleaseCount) · CLEAR \(store.demoClearButtonReleaseCount)")
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.secondary)
+                    Text(
+                        "PLAY \(store.demoPlayButtonReleaseCount) · CLEAR \(store.demoClearButtonReleaseCount)"
+                            + (store.sequencerIsRunning ? " · \(Int(store.sequencerBPM)) BPM" : "")
+                    )
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
                 }
 
                 HStack(alignment: .center, spacing: 48) {

--- a/AcidMe/Core/AppFeature.swift
+++ b/AcidMe/Core/AppFeature.swift
@@ -4,6 +4,9 @@ import Foundation
 /// Raíz TCA de la app. Se ampliará en HUs posteriores (audio, secuenciador, UI).
 @Reducer
 struct AppFeature {
+    enum CancelID: Hashable {
+        case sequencerLoop
+    }
     @ObservableState
     struct State: Equatable {
         static func == (lhs: AppFeature.State, rhs: AppFeature.State) -> Bool {
@@ -19,6 +22,10 @@ struct AppFeature {
             && lhs.keyboardLastNoteOn?.frequencyHz == rhs.keyboardLastNoteOn?.frequencyHz
             && lhs.audioEnginePrepared == rhs.audioEnginePrepared
             && lhs.audioEnginePrepareError == rhs.audioEnginePrepareError
+            && lhs.sequencerIsRunning == rhs.sequencerIsRunning
+            && lhs.sequencerCurrentStep == rhs.sequencerCurrentStep
+            && lhs.sequencerPlayheadStep == rhs.sequencerPlayheadStep
+            && lhs.sequencerBPM == rhs.sequencerBPM
         }
 
         /// Valor de demostración del AcidKnob (HU 1); más adelante se sustituirá por parámetros reales de síntesis.
@@ -39,6 +46,14 @@ struct AppFeature {
         /// HU 6: motor AudioKit listo para recibir comandos.
         var audioEnginePrepared: Bool = false
         var audioEnginePrepareError: String?
+        /// HU 8: transporte y puntero del secuenciador (pasos del piano roll).
+        var sequencerIsRunning: Bool = false
+        /// Paso que se articula en el próximo `sequencerTick`.
+        var sequencerCurrentStep: Int = 0
+        /// Columna resaltada (último paso articulado); `nil` si el transporte está parado.
+        var sequencerPlayheadStep: Int?
+        /// Pulsos por minuto (40…220) para el reloj del secuenciador.
+        var sequencerBPM: Double = 120
     }
 
     enum Action: BindableAction, Equatable {
@@ -57,6 +72,9 @@ struct AppFeature {
         case prepareAudioEngine
         case audioEnginePrepared
         case audioEnginePrepareFailed(String)
+        /// Avanza un paso, dispara notas con ataque en ese paso y actualiza el playhead.
+        case sequencerTick
+        case sequencerStopTapped
     }
 
     var body: some ReducerOf<Self> {
@@ -73,24 +91,52 @@ struct AppFeature {
                     await audioClient.applyDemoSynthParams(k, t)
                 }
             case .demoPlayButtonReleased:
+                guard !state.sequencerIsRunning else { return .none }
                 state.demoPlayButtonReleaseCount += 1
-                return .none
+                state.sequencerIsRunning = true
+                state.sequencerCurrentStep = 0
+                state.sequencerPlayheadStep = nil
+                let steps = PianoRollGridMath.normalizedGridSteps(state.pianoRollGridSteps)
+                let bpm = state.sequencerBPM
+                return .run { send in
+                    while !Task.isCancelled {
+                        let sec = PianoRollSequencerMath.secondsPerStep(bpm: bpm, stepCount: steps)
+                        let ns = min(sec * 1_000_000_000, Double(UInt64.max))
+                        do {
+                            try await Task.sleep(nanoseconds: UInt64(ns))
+                        } catch {
+                            return
+                        }
+                        await send(.sequencerTick)
+                    }
+                }
+                .cancellable(id: CancelID.sequencerLoop, cancelInFlight: true)
             case .demoClearButtonReleased:
                 state.demoClearButtonReleaseCount += 1
                 state.demoKnobValue = 0
                 state.pianoRollNotes = []
+                state.sequencerIsRunning = false
+                state.sequencerCurrentStep = 0
+                state.sequencerPlayheadStep = nil
                 let k = state.demoKnobValue
                 let t = state.demoToggleSelection
-                return .run { _ in
-                    @Dependency(\.audioClient) var audioClient
-                    await audioClient.applyDemoSynthParams(k, t)
-                }
+                return .merge(
+                    .cancel(id: CancelID.sequencerLoop),
+                    .run { _ in
+                        @Dependency(\.audioClient) var audioClient
+                        await audioClient.applyDemoSynthParams(k, t)
+                    }
+                )
             case let .pianoRollGridStepsChanged(raw):
                 let steps = PianoRollGridMath.normalizedGridSteps(raw)
                 state.pianoRollGridSteps = steps
                 state.pianoRollNotes = PianoRollGridMath.clampedNotes(
                     state.pianoRollNotes,
                     stepCount: steps
+                )
+                state.sequencerCurrentStep = min(
+                    max(0, state.sequencerCurrentStep),
+                    max(0, steps - 1)
                 )
                 return .none
             case let .pianoRollStepToggled(row, step):
@@ -161,6 +207,28 @@ struct AppFeature {
                 state.audioEnginePrepared = false
                 state.audioEnginePrepareError = message
                 return .none
+            case .sequencerTick:
+                guard state.sequencerIsRunning else { return .none }
+                let steps = PianoRollGridMath.normalizedGridSteps(state.pianoRollGridSteps)
+                guard steps > 0 else { return .none }
+                let step = state.sequencerCurrentStep
+                let toPlay = PianoRollSequencerMath.notesStarting(atStep: step, in: state.pianoRollNotes)
+                let octave = state.keyboardOctaveOffset
+                state.sequencerPlayheadStep = step
+                state.sequencerCurrentStep = (step + 1) % steps
+                if toPlay.isEmpty { return .none }
+                return .run { _ in
+                    @Dependency(\.audioClient) var audioClient
+                    for n in toPlay {
+                        let midi = PianoRollSequencerMath.midiForRow(n.row, keyboardOctaveOffset: octave)
+                        let hz = AcidKeyboardMath.frequencyHz(midiNote: midi)
+                        await audioClient.triggerSequencerNote(midi, hz)
+                    }
+                }
+            case .sequencerStopTapped:
+                state.sequencerIsRunning = false
+                state.sequencerPlayheadStep = nil
+                return .cancel(id: CancelID.sequencerLoop)
             }
         }
     }

--- a/AcidMe/Core/AudioClient.swift
+++ b/AcidMe/Core/AudioClient.swift
@@ -61,6 +61,14 @@ final class LiveAudioKitEngine {
             sqrOsc.amplitude = level
         }
     }
+
+    /// Ajusta la frecuencia de ambos osciladores al paso del secuenciador (suena el que tenga amplitud > 0).
+    func triggerSequencerNote(midiNote _: Int, frequencyHz: Double) {
+        guard let sawOsc, let sqrOsc else { return }
+        let f = Float(frequencyHz)
+        sawOsc.frequency = f
+        sqrOsc.frequency = f
+    }
 }
 
 private enum DemoSynth {
@@ -72,6 +80,7 @@ private enum DemoSynth {
 struct AudioClient: Sendable {
     var prepare: @Sendable () async throws -> Void
     var applyDemoSynthParams: @Sendable (Double, AcidToggleSelection) async -> Void
+    var triggerSequencerNote: @Sendable (Int, Double) async -> Void
 }
 
 extension AudioClient: DependencyKey {
@@ -81,12 +90,16 @@ extension AudioClient: DependencyKey {
         },
         applyDemoSynthParams: { knob, toggle in
             await LiveAudioKitEngine.shared.applyDemoSynthParams(knobNormalized: knob, toggle: toggle)
+        },
+        triggerSequencerNote: { midi, hz in
+            await LiveAudioKitEngine.shared.triggerSequencerNote(midiNote: midi, frequencyHz: hz)
         }
     )
 
     static let testValue = AudioClient(
         prepare: {},
-        applyDemoSynthParams: { _, _ in }
+        applyDemoSynthParams: { _, _ in },
+        triggerSequencerNote: { _, _ in }
     )
 }
 

--- a/AcidMe/Core/PianoRollSequencerMath.swift
+++ b/AcidMe/Core/PianoRollSequencerMath.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Secuenciador paso a paso alineado con el piano roll y el teclado (HU 8).
+enum PianoRollSequencerMath {
+    /// Duración de un paso en segundos: un compás (4 pulsos) repartido en `stepCount` pasos.
+    static func secondsPerStep(bpm: Double, stepCount: Int) -> Double {
+        let beatsPerBar = 4.0
+        let clampedBpm = min(220, max(40, bpm))
+        let steps = max(1, stepCount)
+        return (60.0 / clampedBpm) * beatsPerBar / Double(steps)
+    }
+
+    /// Fila del roll (0 = arriba B, 11 = abajo C) → MIDI con la misma raíz que el teclado.
+    static func midiForRow(_ row: Int, keyboardOctaveOffset: Int) -> Int {
+        guard row >= 0, row < PianoRollGridMath.rowCount else { return 60 }
+        let fromBottom = PianoRollGridMath.rowCount - 1 - row
+        let root = AcidKeyboardMath.rootMidi(octaveOffset: keyboardOctaveOffset)
+        return min(127, max(0, root + fromBottom))
+    }
+
+    /// Notas con ataque en `step` (inicio de nota en ese paso).
+    static func notesStarting(atStep step: Int, in notes: [PianoRollNote]) -> [PianoRollNote] {
+        notes.filter { $0.startStep == step }
+    }
+}

--- a/AcidMe/Features/Components/AcidPianoRoll.swift
+++ b/AcidMe/Features/Components/AcidPianoRoll.swift
@@ -378,6 +378,8 @@ private struct ActiveNoteResize: Equatable {
 struct AcidPianoRoll: View {
     var gridSteps: Int
     var notes: [PianoRollNote]
+    /// Columna del secuenciador resaltada; `nil` si está parado.
+    var playheadStep: Int?
     var onGridStepsChange: (Int) -> Void
     var onStepTap: (Int, Int) -> Void
     var onStepsPainted: (Int, Int, Int) -> Void
@@ -447,34 +449,49 @@ struct AcidPianoRoll: View {
                         (innerW - CGFloat(stepCount - 1) * spacing) / CGFloat(stepCount)
                     )
                     let stride = cellWidth + spacing
+                    let rows = CGFloat(PianoRollGridMath.rowCount)
+                    let playheadH = rows * rowHeight + (rows - 1) * spacing
 
-                    VStack(alignment: .leading, spacing: spacing) {
-                        HStack(spacing: spacing) {
-                            ForEach(0 ..< stepCount, id: \.self) { s in
-                                Text("\(s + 1)")
-                                    .font(.system(size: 9, weight: .bold, design: .rounded))
-                                    .foregroundStyle(Color(white: 0.94))
-                                    .shadow(color: .black.opacity(0.45), radius: 0, x: 0, y: 0.5)
-                                    .frame(width: cellWidth, height: stepHeaderHeight)
+                    ZStack(alignment: .topLeading) {
+                        VStack(alignment: .leading, spacing: spacing) {
+                            HStack(spacing: spacing) {
+                                ForEach(0 ..< stepCount, id: \.self) { s in
+                                    Text("\(s + 1)")
+                                        .font(.system(size: 9, weight: .bold, design: .rounded))
+                                        .foregroundStyle(Color(white: 0.94))
+                                        .shadow(color: .black.opacity(0.45), radius: 0, x: 0, y: 0.5)
+                                        .frame(width: cellWidth, height: stepHeaderHeight)
+                                }
+                            }
+
+                            VStack(spacing: spacing) {
+                                ForEach(0 ..< PianoRollGridMath.rowCount, id: \.self) { row in
+                                    rowView(
+                                        row: row,
+                                        cellWidth: cellWidth,
+                                        stride: stride
+                                    )
+                                }
                             }
                         }
+                        .padding(.init(
+                            top: gridPaddingTop,
+                            leading: gridPaddingLeading,
+                            bottom: gridPaddingBottom,
+                            trailing: gridPaddingTrailing
+                        ))
 
-                        VStack(spacing: spacing) {
-                            ForEach(0 ..< PianoRollGridMath.rowCount, id: \.self) { row in
-                                rowView(
-                                    row: row,
-                                    cellWidth: cellWidth,
-                                    stride: stride
+                        if let ph = playheadStep, ph >= 0, ph < stepCount {
+                            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                                .fill(Color(red: 0.98, green: 0.88, blue: 0.12).opacity(0.42))
+                                .frame(width: cellWidth, height: playheadH)
+                                .offset(
+                                    x: gridPaddingLeading + CGFloat(ph) * stride,
+                                    y: gridPaddingTop + stepHeaderHeight + spacing
                                 )
-                            }
+                                .allowsHitTesting(false)
                         }
                     }
-                    .padding(.init(
-                        top: gridPaddingTop,
-                        leading: gridPaddingLeading,
-                        bottom: gridPaddingBottom,
-                        trailing: gridPaddingTrailing
-                    ))
                     .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
                     .background(
                         RoundedRectangle(cornerRadius: 10, style: .continuous)
@@ -683,6 +700,7 @@ struct AcidPianoRoll: View {
             AcidPianoRoll(
                 gridSteps: gridSteps,
                 notes: notes,
+                playheadStep: nil,
                 onGridStepsChange: { gridSteps = $0 },
                 onStepTap: { r, s in
                     notes = PianoRollGridMath.togglingStep(

--- a/AcidMeTests/AppFeatureTests.swift
+++ b/AcidMeTests/AppFeatureTests.swift
@@ -40,7 +40,8 @@ struct AppFeatureTests {
                 applyDemoSynthParams: { k, t in
                     lastKnob = k
                     lastToggle = t
-                }
+                },
+                triggerSequencerNote: { _, _ in }
             )
         }
         await store.send(.binding(.set(\.demoKnobValue, 0.7))) {
@@ -70,13 +71,42 @@ struct AppFeatureTests {
     }
 
     @Test
-    func demoPlayButtonReleased_incrementaContador() async {
+    func demoPlayButtonReleased_iniciaTransporteYContador() async {
         let store = TestStore(initialState: AppFeature.State()) {
             AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { _, _ in },
+                triggerSequencerNote: { _, _ in }
+            )
         }
         await store.send(.demoPlayButtonReleased) {
             $0.demoPlayButtonReleaseCount = 1
+            $0.sequencerIsRunning = true
+            $0.sequencerCurrentStep = 0
+            $0.sequencerPlayheadStep = nil
         }
+        await store.send(.sequencerStopTapped) {
+            $0.sequencerIsRunning = false
+            $0.sequencerPlayheadStep = nil
+        }
+    }
+
+    @Test
+    func demoPlayButtonReleased_ignoraSiYaCorre() async {
+        var state = AppFeature.State()
+        state.sequencerIsRunning = true
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { _, _ in },
+                triggerSequencerNote: { _, _ in }
+            )
+        }
+        await store.send(.demoPlayButtonReleased)
     }
 
     @Test
@@ -89,13 +119,17 @@ struct AppFeatureTests {
                 prepare: {},
                 applyDemoSynthParams: { k, _ in
                     lastKnob = k
-                }
+                },
+                triggerSequencerNote: { _, _ in }
             )
         }
         await store.send(.demoClearButtonReleased) {
             $0.demoClearButtonReleaseCount = 1
             $0.demoKnobValue = 0
             $0.pianoRollNotes = []
+            $0.sequencerIsRunning = false
+            $0.sequencerCurrentStep = 0
+            $0.sequencerPlayheadStep = nil
         }
         #expect(lastKnob == 0)
     }
@@ -128,13 +162,17 @@ struct AppFeatureTests {
                 prepare: {},
                 applyDemoSynthParams: { _, _ in
                     applyCount += 1
-                }
+                },
+                triggerSequencerNote: { _, _ in }
             )
         }
         await store.send(.demoClearButtonReleased) {
             $0.demoClearButtonReleaseCount = 1
             $0.demoKnobValue = 0
             $0.pianoRollNotes = []
+            $0.sequencerIsRunning = false
+            $0.sequencerCurrentStep = 0
+            $0.sequencerPlayheadStep = nil
         }
         #expect(applyCount == 1)
     }
@@ -200,7 +238,8 @@ struct AppFeatureTests {
                 prepare: { prepareCalls += 1 },
                 applyDemoSynthParams: { _, _ in
                     applyCalls += 1
-                }
+                },
+                triggerSequencerNote: { _, _ in }
             )
         }
         await store.send(.prepareAudioEngine)
@@ -226,7 +265,8 @@ struct AppFeatureTests {
                 applyDemoSynthParams: { k, t in
                     lastKnob = k
                     lastToggle = t
-                }
+                },
+                triggerSequencerNote: { _, _ in }
             )
         }
         await store.send(.prepareAudioEngine)
@@ -247,13 +287,94 @@ struct AppFeatureTests {
                 prepare: {
                     throw NSError(domain: "test", code: 1, userInfo: [NSLocalizedDescriptionKey: "fallo simulado"])
                 },
-                applyDemoSynthParams: { _, _ in }
+                applyDemoSynthParams: { _, _ in },
+                triggerSequencerNote: { _, _ in }
             )
         }
         await store.send(.prepareAudioEngine)
         await store.receive(.audioEnginePrepareFailed("fallo simulado")) {
             $0.audioEnginePrepared = false
             $0.audioEnginePrepareError = "fallo simulado"
+        }
+    }
+
+    @Test
+    func sequencerTick_avanzaPasoYPlayhead() async {
+        let store = TestStore(
+            initialState: AppFeature.State(
+                sequencerIsRunning: true,
+                sequencerCurrentStep: 0,
+                pianoRollGridSteps: 16,
+                pianoRollNotes: []
+            )
+        ) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { _, _ in },
+                triggerSequencerNote: { _, _ in }
+            )
+        }
+        await store.send(.sequencerTick) {
+            $0.sequencerPlayheadStep = 0
+            $0.sequencerCurrentStep = 1
+        }
+    }
+
+    @Test
+    func sequencerTick_disparaNotaInicioEnPaso() async {
+        let id = UUID()
+        var triggered: [(Int, Double)] = []
+        let store = TestStore(
+            initialState: AppFeature.State(
+                sequencerIsRunning: true,
+                sequencerCurrentStep: 2,
+                pianoRollGridSteps: 16,
+                pianoRollNotes: [
+                    PianoRollNote(id: id, row: 11, startStep: 2, lengthSteps: 2)
+                ],
+                keyboardOctaveOffset: 0
+            )
+        ) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { _, _ in },
+                triggerSequencerNote: { m, h in
+                    triggered.append((m, h))
+                }
+            )
+        }
+        let expectedMidi = PianoRollSequencerMath.midiForRow(11, keyboardOctaveOffset: 0)
+        let expectedHz = AcidKeyboardMath.frequencyHz(midiNote: expectedMidi)
+        await store.send(.sequencerTick) {
+            $0.sequencerPlayheadStep = 2
+            $0.sequencerCurrentStep = 3
+        }
+        #expect(triggered.count == 1)
+        #expect(triggered[0].0 == expectedMidi)
+        #expect(abs(triggered[0].1 - expectedHz) < 1e-9)
+    }
+
+    @Test
+    func sequencerStopTapped_detieneTransporte() async {
+        var state = AppFeature.State()
+        state.sequencerIsRunning = true
+        state.sequencerPlayheadStep = 5
+        let store = TestStore(initialState: state) {
+            AppFeature()
+        } withDependencies: {
+            $0.audioClient = AudioClient(
+                prepare: {},
+                applyDemoSynthParams: { _, _ in },
+                triggerSequencerNote: { _, _ in }
+            )
+        }
+        await store.send(.sequencerStopTapped) {
+            $0.sequencerIsRunning = false
+            $0.sequencerPlayheadStep = nil
         }
     }
 
@@ -265,6 +386,21 @@ struct AppFeatureTests {
         b.audioEnginePrepared = true
         #expect(a == b)
         b.audioEnginePrepareError = "x"
+        #expect(a != b)
+    }
+
+    @Test
+    func stateEquality_incluyeSequencer() {
+        var a = AppFeature.State()
+        var b = AppFeature.State()
+        a.sequencerIsRunning = true
+        a.sequencerCurrentStep = 3
+        a.sequencerPlayheadStep = 2
+        b.sequencerIsRunning = true
+        b.sequencerCurrentStep = 3
+        b.sequencerPlayheadStep = 2
+        #expect(a == b)
+        b.sequencerBPM = 140
         #expect(a != b)
     }
 

--- a/AcidMeTests/PianoRollSequencerMathTests.swift
+++ b/AcidMeTests/PianoRollSequencerMathTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import AcidMe
+
+@Suite
+struct PianoRollSequencerMathTests {
+    @Test
+    func secondsPerStep_bpm120_16pasos() {
+        let s = PianoRollSequencerMath.secondsPerStep(bpm: 120, stepCount: 16)
+        #expect(abs(s - 0.125) < 0.0001)
+    }
+
+    @Test
+    func secondsPerStep_acotaBPM() {
+        let low = PianoRollSequencerMath.secondsPerStep(bpm: 10, stepCount: 16)
+        let high = PianoRollSequencerMath.secondsPerStep(bpm: 400, stepCount: 16)
+        let ref40 = PianoRollSequencerMath.secondsPerStep(bpm: 40, stepCount: 16)
+        let ref220 = PianoRollSequencerMath.secondsPerStep(bpm: 220, stepCount: 16)
+        #expect(low == ref40)
+        #expect(high == ref220)
+    }
+
+    @Test
+    func midiForRow_alineadoConTecladoOctava0() {
+        let bottom = PianoRollSequencerMath.midiForRow(11, keyboardOctaveOffset: 0)
+        #expect(bottom == AcidKeyboardMath.rootMidi(octaveOffset: 0))
+        let top = PianoRollSequencerMath.midiForRow(0, keyboardOctaveOffset: 0)
+        #expect(top == AcidKeyboardMath.rootMidi(octaveOffset: 0) + 11)
+    }
+
+    @Test
+    func notesStarting_filtraPorPaso() {
+        let notes = [
+            PianoRollNote(id: UUID(), row: 0, startStep: 0, lengthSteps: 1),
+            PianoRollNote(id: UUID(), row: 1, startStep: 3, lengthSteps: 2)
+        ]
+        let a = PianoRollSequencerMath.notesStarting(atStep: 0, in: notes)
+        #expect(a.count == 1)
+        #expect(a[0].row == 0)
+        let b = PianoRollSequencerMath.notesStarting(atStep: 3, in: notes)
+        #expect(b.count == 1)
+        #expect(b[0].row == 1)
+        #expect(PianoRollSequencerMath.notesStarting(atStep: 1, in: notes).isEmpty)
+    }
+}


### PR DESCRIPTION
## HU 8
- **Transporte**: PLAY arranca el reloj (un compás repartido en los pasos de la rejilla; BPM fijo 120 en estado). STOP y CLEAR detienen y cancelan el bucle (`CancelID.sequencerLoop`).
- **Puntero**: columna resaltada en el piano roll mientras corre; `sequencerTick` articula en el paso actual y avanza.
- **Audio**: por cada nota con `startStep == paso`, `AudioClient.triggerSequencerNote` ajusta la frecuencia de los osciladores (misma raíz MIDI que el teclado vía `PianoRollSequencerMath`).
- **Tests**: `PianoRollSequencerMathTests`, tests de reducer (`sequencerTick`, PLAY/STOP, CLEAR, igualdad de estado).

## Probar
`xcodebuild -scheme AcidMe -destination 'platform=iOS Simulator,name=iPhone 16' test`

Made with [Cursor](https://cursor.com)